### PR TITLE
Added ZeroSpline again and test for Loess

### DIFF
--- a/src/caches/interpolation_caches.jl
+++ b/src/caches/interpolation_caches.jl
@@ -23,6 +23,15 @@ struct LagrangeInterpolation{uType,tType,FT,T} <: AbstractInterpolation{FT,T}
 end
 LagrangeInterpolation(u,t,n) = LagrangeInterpolation{true}(u,t,n)
 
+### ZeroSpline Interpolation
+struct ZeroSpline{uType,tType,dirType,FT,T} <: AbstractInterpolation{FT,T}
+  u::uType
+  t::tType
+  dir::Symbol
+  ZeroSpline{FT}(u,t,dir) where FT = new{typeof(u),typeof(t),typeof(dir),FT,eltype(u)}(u,t,dir)
+end
+ ZeroSpline(u,t;dir=:left) = ZeroSpline{true}(u,t,dir)
+
 ### QuadraticSpline Interpolation
 struct QuadraticSpline{uType,tType,tAType,dType,zType,FT,T} <: AbstractInterpolation{FT,T}
   u::uType

--- a/src/interpolation_alg/interpolation_methods.jl
+++ b/src/interpolation_alg/interpolation_methods.jl
@@ -73,6 +73,26 @@ function (A::LagrangeInterpolation{<:AbstractMatrix{<:Number}})(t::Number)
   N/D
 end
 
+# ZeroSpline Interpolation
+function (A::ZeroSpline{<:AbstractVector{<:Number}})(t::Number)
+  i = findfirst(x->x>=t,A.t)
+  i == 1 ? i += 1 : nothing
+  if A.dir == :left
+    return A.u[i-1]
+  else
+    return A.u[i]
+  end
+end
+ function (A::ZeroSpline{<:AbstractMatrix{<:Number}})(t::Number)
+  i = findfirst(x->x>=t,A.t)
+  i == 1 ? i += 1 : nothing
+  if A.dir == :left
+    return A.u[:,i-1]
+  else
+    return A.u[:,i]
+  end
+end
+
 # QuadraticSpline Interpolation
 function (A::QuadraticSpline{<:AbstractVector{<:Number}})(t::Number)
   i = findfirst(x->x>=t,A.t)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -111,3 +111,20 @@ A = CubicSpline(u,t)
 @test A(-1.0) == 0.0
 @test A(0.0) == 1.0
 @test A(1.0) == 3.0
+
+# Loess Interpolation
+# test against Loess.jl [https://github.com/JuliaStats/Loess.jl]
+# Currently, Loess.jl is not compatible with Julia 1.0
+
+# using Loess
+# xs = [1.0 * x for x in 1:20]
+# ys = [1.0 * x * x for x in 1:20]
+# us = collect(minimum(xs):0.1:maximum(xs))
+
+# model = loess(xs, ys)
+# vs = predict(model, us)
+
+# A = Loess(u,t,2,0.75)
+# uu = A.(us)
+
+# @test vs ≈ uu


### PR DESCRIPTION
`ZeroSpline` is missing from master branch, I don't know how did this happen so I am adding it again.
Currently `Loess.jl` is not compatible with Julia 1.0, so I commented out Loess test part.
I have tested our Loess againt Loess.jl here, https://github.com/UMCTM/DataInterpolations.jl/pull/14#issuecomment-429515670