### PR TITLE
Compat bound QuadGK

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,6 +24,7 @@ DataInterpolationsSymbolicsExt = "Symbolics"
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
 Optim = "0.19, 0.20, 0.21, 0.22, 1.0"
+QuadGK = "=2.8"
 RecipesBase = "0.8, 1.0"
 RecursiveArrayTools = "2"
 Reexport = "0.2, 1.0"
@@ -31,7 +32,6 @@ RegularizationTools = "0.6"
 Requires = "1"
 Symbolics = "4, 5.1"
 julia = "1.6"
-
 
 [extras]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"


### PR DESCRIPTION
There seems to be an issue with QuadGK@2.9 - https://github.com/JuliaMath/QuadGK.jl/issues/89
Hence bounding the compat at 2.8