### PR TITLE
Fix Extrapolation for methods

### DIFF
--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -111,6 +111,7 @@ end
 function _interpolate(A::LagrangeInterpolation{<:AbstractVector}, t::Number, i)
     _interpolate(A, t), i
 end
+
 function _interpolate(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number, i)
     _interpolate(A, t), i
 end
@@ -170,6 +171,8 @@ end
 function _interpolate(A::BSplineInterpolation{<:AbstractVector{<:Number}},
     t::Number,
     iguess)
+    t < A.t[1] && return A.u[1], 1
+    t > A.t[end] && return A.u[end], lastindex(t)
     # change t into param [0 1]
     idx = searchsortedlastcorrelated(A.t, t, iguess)
     idx == length(A.t) ? idx -= 1 : nothing
@@ -185,6 +188,8 @@ end
 
 # BSpline Curve Approx
 function _interpolate(A::BSplineApprox{<:AbstractVector{<:Number}}, t::Number, iguess)
+    t < A.t[1] && return A.u[1], 1
+    t > A.t[end] && return A.u[end], lastindex(t)
     # change t into param [0 1]
     idx = searchsortedlastcorrelated(A.t, t, iguess)
     idx == length(A.t) ? idx -= 1 : nothing

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -3,11 +3,9 @@ using FiniteDifferences
 using DataInterpolations: derivative
 
 function test_derivatives(func, tspan, name::String)
-    trange = range(minimum(tspan), maximum(tspan), length = 32)[2:(end - 1)]
+    trange = range(minimum(tspan) - 5.0, maximum(tspan) + 5.0, length = 32)
     @testset "$name" begin
         for t in trange
-            # Linearly spaced points might lead to evaluations outside
-            # trange
             cdiff = central_fdm(5, 1; geom = true)(_t -> func(_t), t)
             adiff = derivative(func, t)
             @test isapprox(cdiff, adiff, atol = 1e-8)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -476,21 +476,27 @@ u = [14.7, 11.51, 10.41, 14.95, 12.24, 11.22]
 
 A = BSplineInterpolation(u, t, 2, :Uniform, :Uniform)
 
+@test A(-1.0) == u[1]
 @test [A(25.0), A(80.0)] == [13.454197730061425, 10.305633616059845]
 @test [A(190.0), A(225.0)] == [14.07428439395079, 11.057784141519251]
 @test [A(t[1]), A(t[end])] == [u[1], u[end]]
+@test A(300.0) == u[end]
 
 A = BSplineInterpolation(u, t, 2, :ArcLen, :Average)
 
+@test A(-1.0) == u[1]
 @test [A(25.0), A(80.0)] == [13.363814458968486, 10.685201117692609]
 @test [A(190.0), A(225.0)] == [13.437481084762863, 11.367034741256463]
 @test [A(t[1]), A(t[end])] == [u[1], u[end]]
+@test A(300.0) == u[end]
 
 A = BSplineApprox(u, t, 2, 4, :Uniform, :Uniform)
 
+@test A(-1.0) == u[1]
 @test [A(25.0), A(80.0)] ≈ [12.979802931218234, 10.914310609953178]
 @test [A(190.0), A(225.0)] ≈ [13.851245975109263, 12.963685868886575]
 @test [A(t[1]), A(t[end])] ≈ [u[1], u[end]]
+@test A(300.0) == u[end]
 
 # Curvefit Interpolation
 rng = StableRNG(12345)


### PR DESCRIPTION
This PR fixes:

1. Extrapolation for `BSplineInterpolation` and `BSplineApprox` - this is made constant equal to the endpoint
2. Derivative at right end point for `BSplineApprox`
3. Extrapolation of derivatives for `LinearInterpolation`, `QuadraticSpline`, `CubicSpline`,  `BSplineInterpolation` and `BSplineApprox`

Partial fix towards: https://github.com/SciML/DataInterpolations.jl/issues/175