### PR TITLE
build: bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "4.2.0"
+version = "4.2.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
@ChrisRackauckas can we merge this and release? This is needed for `BSplineApprox` derivatives to work which was fixed in https://github.com/SciML/DataInterpolations.jl/pull/184