### PR TITLE
Bypass bracketing for AbstractRanges

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -123,3 +123,6 @@ function searchsortedlastcorrelated(v::AbstractVector, x, guess)
     lo, hi = bracketstrictlymontonic(v, x, guess, Base.Order.Forward)
     searchsortedlast(v, x, lo, hi, Base.Order.Forward)
 end
+
+searchsortedfirstcorrelated(r::AbstractRange, x, _) = searchsortedfirst(r, x)
+searchsortedlastcorrelated(r::AbstractRange, x, _) = searchsortedlast(r, x)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -4,36 +4,41 @@ using Optim
 import ForwardDiff
 
 @testset "Linear Interpolation" begin
-    u = 2.0collect(1:10)
-    t = 1.0collect(1:10)
-    A = LinearInterpolation(u, t)
+    for t in (1.0:10.0, 1.0collect(1:10))
+        u = 2.0collect(1:10)
+        #t = 1.0collect(1:10)
+        A = LinearInterpolation(u, t)
 
-    for (_t, _u) in zip(t, u)
-        @test A(_t) == _u
+        for (_t, _u) in zip(t, u)
+            @test A(_t) == _u
+        end
+        @test A(0) == 0.0
+        @test A(5.5) == 11.0
+        @test A(11) == 22
+
+        u = vcat(2.0collect(1:10)', 3.0collect(1:10)')
+        A = LinearInterpolation(u, t)
+
+        for (_t, _u) in zip(t, eachcol(u))
+            @test A(_t) == _u
+        end
+        @test A(0) == [0.0, 0.0]
+        @test A(5.5) == [11.0, 16.5]
+        @test A(11) == [22, 33]
+
+        x = 1:10
+        y = 2:4
+        u_ = x' .* y
+        u = [u_[:, i] for i in 1:size(u_, 2)]
+        A = LinearInterpolation(u, t)
+        @test A(0) == [0.0, 0.0, 0.0]
+        @test A(5.5) == [11.0, 16.5, 22.0]
+        @test A(11) == [22.0, 33.0, 44.0]
     end
-    @test A(0) == 0.0
-    @test A(5.5) == 11.0
-    @test A(11) == 22
-
-    u = vcat(2.0collect(1:10)', 3.0collect(1:10)')
-    A = LinearInterpolation(u, t)
-
-    for (_t, _u) in zip(t, eachcol(u))
-        @test A(_t) == _u
-    end
-    @test A(0) == [0.0, 0.0]
-    @test A(5.5) == [11.0, 16.5]
-    @test A(11) == [22, 33]
 
     x = 1:10
     y = 2:4
     u_ = x' .* y
-    u = [u_[:, i] for i in 1:size(u_, 2)]
-    A = LinearInterpolation(u, t)
-    @test A(0) == [0.0, 0.0, 0.0]
-    @test A(5.5) == [11.0, 16.5, 22.0]
-    @test A(11) == [22.0, 33.0, 44.0]
-
     u = [u_[:, i:(i + 1)] for i in 1:2:10]
     t = 1.0collect(2:2:10)
     A = LinearInterpolation(u, t)


### PR DESCRIPTION
Bypass the `bracketstrictlymontonic` stage of the index lookup for ranges in `searchsorted...correlated`, because the corresponding `searchsorted...` functions for ranges in `Base` already do O(1) exact lookup without searching. This results in faster interpolation when `t` is a range. The first linear interpolation tests are also repeated for ranges.

Benchmark: 

```julia using DataInterpolations, BenchmarkTools

exec_times = Float64[]
for x in 3:9 
    N = 10^x
    u = rand(N)
    t = 1:N
    li = LinearInterpolation(u, t)
    b = @benchmark $li(rand($t))
    push!(exec_times, mean(b.times))
end
```

Results (the jump in latency in the PR at some points is probably because of cache misses as we're interpolating random elements):

![image](https://github.com/SciML/DataInterpolations.jl/assets/8618033/10b879d3-1966-4739-bcfd-e2eaf2f9f5c6)

Close #187 