### PR TITLE
fix(bounds): allow interpolation on bounds of time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "4.4.0"
+version = "4.4.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -1,5 +1,5 @@
 function derivative(A, t)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     derivative(A, t, firstindex(A.t) - 1)[1]
 end
 
@@ -36,7 +36,7 @@ function derivative(A::QuadraticInterpolation{<:AbstractMatrix}, t::Number, igue
 end
 
 function derivative(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     idxs = findRequiredIdxs(A, t)
     if A.t[idxs[1]] == t
         return zero(A.u[idxs[1]])
@@ -72,7 +72,7 @@ function derivative(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
 end
 
 function derivative(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     idxs = findRequiredIdxs(A, t)
     if A.t[idxs[1]] == t
         return zero(A.u[:, idxs[1]])
@@ -120,12 +120,12 @@ function derivative(A::AkimaInterpolation{<:AbstractVector}, t::Number, iguess)
 end
 
 function derivative(A::ConstantInterpolation{<:AbstractVector}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     return isempty(searchsorted(A.t, t)) ? zero(A.u[1]) : eltype(A.u)(NaN)
 end
 
 function derivative(A::ConstantInterpolation{<:AbstractMatrix}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     return isempty(searchsorted(A.t, t)) ? zero(A.u[:, 1]) : eltype(A.u)(NaN) .* A.u[:, 1]
 end
 

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,5 +1,5 @@
 function _interpolate(interp, t)
-    ((t < interp.t[1] || t > interp.t[end]) && !interp.extrapolate) &&
+    ((t <= interp.t[1] || t >= interp.t[end]) && !interp.extrapolate) &&
         throw(ExtrapolationError())
     _interpolate(interp, t, firstindex(interp.t) - 1)[1]
 end
@@ -57,7 +57,7 @@ end
 
 # Lagrange Interpolation
 function _interpolate(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     idxs = findRequiredIdxs(A, t)
     if A.t[idxs[1]] == t
         return A.u[idxs[1]]
@@ -86,7 +86,7 @@ function _interpolate(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
 end
 
 function _interpolate(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number)
-    ((t < A.t[1] || t > A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
+    ((t <= A.t[1] || t >= A.t[end]) && !A.extrapolate) && throw(ExtrapolationError())
     idxs = findRequiredIdxs(A, t)
     if A.t[idxs[1]] == t
         return A.u[:, idxs[1]]


### PR DESCRIPTION
Currently if one tries to call interpolation for the extremities of the timespan for which the splines are fit, we get the `ExtrapolationError` whereas it isn't actually doing extrapolation. This relaxes the checks for where we query to include those bounds.

Perhaps better checks are needed for when we query with something not time (i.e not linear, sorted, or monotonic)