### PR TITLE
Add derivatives for `RegularizationSmooth` and `Curvefit`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
 DataInterpolationsChainRulesCoreExt = "ChainRulesCore"
-DataInterpolationsOptimExt = "Optim"
+DataInterpolationsOptimExt = ["ForwardDiff", "Optim"]
 DataInterpolationsRegularizationToolsExt = "RegularizationTools"
 DataInterpolationsSymbolicsExt = "Symbolics"
 

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
@@ -24,6 +25,7 @@ DataInterpolationsSymbolicsExt = "Symbolics"
 
 [compat]
 ChainRulesCore = "0.9.44, 0.10, 1"
+ForwardDiff = "0.10"
 LinearAlgebra = "1.6"
 Optim = "0.19, 0.20, 0.21, 0.22, 1.0"
 PrettyTables = "2"

--- a/ext/DataInterpolationsChainRulesCoreExt.jl
+++ b/ext/DataInterpolationsChainRulesCoreExt.jl
@@ -11,20 +11,20 @@ else
 end
 
 function ChainRulesCore.rrule(::typeof(_interpolate),
-    A::Union{
-        LagrangeInterpolation,
-        AkimaInterpolation,
-        BSplineInterpolation,
-        BSplineApprox,
-    },
-    t::Number)
+        A::Union{
+            LagrangeInterpolation,
+            AkimaInterpolation,
+            BSplineInterpolation,
+            BSplineApprox,
+        },
+        t::Number)
     deriv = derivative(A, t)
     interpolate_pullback(Δ) = (NoTangent(), NoTangent(), deriv * Δ)
     return _interpolate(A, t), interpolate_pullback
 end
 
 function ChainRulesCore.frule((_, _, Δt), ::typeof(_interpolate), A::AbstractInterpolation,
-    t::Number)
+        t::Number)
     return _interpolate(A, t), derivative(A, t) * Δt
 end
 

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -64,7 +64,7 @@ function derivative(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
                 tmp += k
             end
         end
-        der += A.u[j]*tmp
+        der += A.u[j] * tmp
     end
     der
 end
@@ -98,7 +98,7 @@ function derivative(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number)
                 tmp += k
             end
         end
-        @. der += A.u[:, j]*tmp
+        @. der += A.u[:, j] * tmp
     end
     der
 end

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -24,8 +24,8 @@ end
 
 samples(A::LinearInterpolation{<:AbstractVector}) = (0, 1)
 function _integral(A::LinearInterpolation{<:AbstractVector{<:Number}},
-    idx::Number,
-    t::Number)
+        idx::Number,
+        t::Number)
     t1 = A.t[idx]
     t2 = A.t[idx + 1]
     u1 = A.u[idx]
@@ -46,8 +46,8 @@ end
 
 samples(A::QuadraticInterpolation{<:AbstractVector}) = (0, 1)
 function _integral(A::QuadraticInterpolation{<:AbstractVector{<:Number}},
-    idx::Number,
-    t::Number)
+        idx::Number,
+        t::Number)
     A.mode == :Backward && idx > 1 && (idx -= 1)
     idx = min(length(A.t) - 2, idx)
     t1 = A.t[idx]

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -149,8 +149,8 @@ struct QuadraticSpline{uType, tType, tAType, dType, zType, FT, T} <:
 end
 
 function QuadraticSpline(u::uType,
-    t;
-    extrapolate = false) where {uType <: AbstractVector{<:Number}}
+        t;
+        extrapolate = false) where {uType <: AbstractVector{<:Number}}
     u, t = munge_data(u, t)
     s = length(t)
     dl = ones(eltype(t), s - 1)
@@ -199,8 +199,8 @@ struct CubicSpline{uType, tType, hType, zType, FT, T} <: AbstractInterpolation{F
 end
 
 function CubicSpline(u::uType,
-    t;
-    extrapolate = false) where {uType <: AbstractVector{<:Number}}
+        t;
+        extrapolate = false) where {uType <: AbstractVector{<:Number}}
     u, t = munge_data(u, t)
     n = length(t) - 1
     h = vcat(0, map(k -> t[k + 1] - t[k], 1:(length(t) - 1)), 0)
@@ -250,14 +250,14 @@ struct BSplineInterpolation{uType, tType, pType, kType, cType, FT, T} <:
     knotVecType::Symbol
     extrapolate::Bool
     function BSplineInterpolation{FT}(u,
-        t,
-        d,
-        p,
-        k,
-        c,
-        pVecType,
-        knotVecType,
-        extrapolate) where {FT}
+            t,
+            d,
+            p,
+            k,
+            c,
+            pVecType,
+            knotVecType,
+            extrapolate) where {FT}
         new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), FT, eltype(u)}(u,
             t,
             d,
@@ -348,15 +348,15 @@ struct BSplineApprox{uType, tType, pType, kType, cType, FT, T} <:
     knotVecType::Symbol
     extrapolate::Bool
     function BSplineApprox{FT}(u,
-        t,
-        d,
-        h,
-        p,
-        k,
-        c,
-        pVecType,
-        knotVecType,
-        extrapolate) where {FT}
+            t,
+            d,
+            h,
+            p,
+            k,
+            c,
+            pVecType,
+            knotVecType,
+            extrapolate) where {FT}
         new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), FT, eltype(u)}(u,
             t,
             d,

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -175,8 +175,8 @@ end
 
 # BSpline Curve Interpolation
 function _interpolate(A::BSplineInterpolation{<:AbstractVector{<:Number}},
-    t::Number,
-    iguess)
+        t::Number,
+        iguess)
     t < A.t[1] && return A.u[1], 1
     t > A.t[end] && return A.u[end], lastindex(t)
     # change t into param [0 1]

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -82,9 +82,9 @@ this function would be the index returned by the previous call to `searchsorted`
 See [`sort!`](@ref) for an explanation of the keyword arguments `by`, `lt` and `rev`.
 """
 function bracketstrictlymontonic(v::AbstractVector,
-    x,
-    guess::T,
-    o::Base.Order.Ordering)::NTuple{2, keytype(v)} where {T <: Integer}
+        x,
+        guess::T,
+        o::Base.Order.Ordering)::NTuple{2, keytype(v)} where {T <: Integer}
     bottom = firstindex(v)
     top = lastindex(v)
     if guess < bottom || guess > top

--- a/src/plot_rec.jl
+++ b/src/plot_rec.jl
@@ -32,11 +32,11 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:linear_interp}},
-    x,
-    y,
-    z;
-    plotdensity = 10_000,
-    denseplot = true)
+        x,
+        y,
+        z;
+        plotdensity = 10_000,
+        denseplot = true)
     seriestype := :path
 
     label --> "Linear fit"
@@ -54,11 +54,11 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:quadratic_interp}},
-    x,
-    y,
-    z;
-    plotdensity = 10_000,
-    denseplot = true)
+        x,
+        y,
+        z;
+        plotdensity = 10_000,
+        denseplot = true)
     seriestype := :path
 
     label --> "Quadratic fit"
@@ -76,11 +76,11 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:quadratic_spline}},
-    x,
-    y,
-    z;
-    plotdensity = 10_000,
-    denseplot = true)
+        x,
+        y,
+        z;
+        plotdensity = 10_000,
+        denseplot = true)
     seriestype := :path
 
     label --> "Quadratic Spline"
@@ -101,10 +101,10 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:lagrange_interp}},
-    x, y, z;
-    n = length(x) - 1,
-    plotdensity = 10_000,
-    denseplot = true)
+        x, y, z;
+        n = length(x) - 1,
+        plotdensity = 10_000,
+        denseplot = true)
     seriestype := :path
 
     label --> "Lagrange Fit"
@@ -126,11 +126,11 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:cubic_spline}},
-    x,
-    y,
-    z;
-    plotdensity = 10_000,
-    denseplot = true)
+        x,
+        y,
+        z;
+        plotdensity = 10_000,
+        denseplot = true)
     seriestype := :path
 
     label --> "Cubic Spline"
@@ -146,12 +146,12 @@ end
 end
 
 @recipe function f(::Type{Val{:bspline_interp}},
-    x, y, z;
-    d = 5,
-    pVec = :ArcLen,
-    knotVec = :Average,
-    plotdensity = length(x) * 6,
-    denseplot = true)
+        x, y, z;
+        d = 5,
+        pVec = :ArcLen,
+        knotVec = :Average,
+        plotdensity = length(x) * 6,
+        denseplot = true)
     seriestype := :path
 
     label --> "B-Spline"
@@ -176,13 +176,13 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:bspline_approx}},
-    x, y, z;
-    d = 5,
-    h = length(x) - 1,
-    pVec = :ArcLen,
-    knotVec = :Average,
-    plotdensity = length(x) * 6,
-    denseplot = true)
+        x, y, z;
+        d = 5,
+        h = length(x) - 1,
+        pVec = :ArcLen,
+        knotVec = :Average,
+        plotdensity = length(x) * 6,
+        denseplot = true)
     seriestype := :path
 
     label --> "B-Spline"
@@ -206,11 +206,11 @@ end
 ########################################
 
 @recipe function f(::Type{Val{:akima}},
-    x,
-    y,
-    z;
-    plotdensity = length(x) * 6,
-    denseplot = true)
+        x,
+        y,
+        z;
+        plotdensity = length(x) * 6,
+        denseplot = true)
     seriestype := :path
 
     label --> "Akima"

--- a/test/regularization.jl
+++ b/test/regularization.jl
@@ -177,3 +177,10 @@ end
     @test isapprox(A.û, ans, rtol = tolerance)
     @test isapprox(A.(t̂), ans, rtol = tolerance)
 end
+
+@testset "Extrapolation" begin
+    A = RegularizationSmooth(uₒ, tₒ; alg = :fixed, extrapolate = true)
+    @test A(10.0) == A.Aitp(10.0)
+    A = RegularizationSmooth(uₒ, tₒ; alg = :fixed)
+    @test_throws DataInterpolations.ExtrapolationError A(10.0)
+end


### PR DESCRIPTION
This PR does the following:

1. Add derivatives for `RegularizationSmooth` using derivatives of CubicSplines as it fits a CubicSpline after solving the optimization problem
2. Add derivatives for `Curvefit` using ForwardDiff
3. Added tests for both
4. Added `extrapolate` keyword to both to make it consistent with other methods
5. Reorganized the extension files for more consistency
6. Formatted the repo

Partial fix towards https://github.com/SciML/DataInterpolations.jl/issues/175