### PR TITLE
build: bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "4.7.0"
+version = "4.7.1"
 
 [deps]
 FindFirstFunctions = "64ca27bc-2ba2-4a57-88aa-44e436879224"


### PR DESCRIPTION
We should have a patch release as CubicSpline had a genuine bug (https://github.com/SciML/DataInterpolations.jl/pull/235).