### PR TITLE
fix: eltype of N in `spline_coefficients` to allow working with dual numbers

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -4,7 +4,7 @@ function findRequiredIdxs(A::LagrangeInterpolation, t)
 end
 
 function spline_coefficients(n, d, k, u::Number)
-    N = zeros(n)
+    N = zeros(eltype(u), n)
     if u == k[1]
         N[1] = one(u)
     elseif u == k[end]


### PR DESCRIPTION
This would allow to use ForwardDiff for derivatives of BSplines

MWE:

```julia
using DataInterpolations, ForwardDiff

u = [14.7, 11.51, 10.41, 14.95, 12.24, 11.22]
t = [0.0, 62.25, 109.66, 162.66, 205.8, 252.3]

sd = t -> ForwardDiff.derivative(Base.Fix1(DataInterpolations.derivative, A), t)
sd(0.0)
```

Stacktrace:

```julia
ERROR: MethodError: no method matching Float64(::ForwardDiff.Dual{ForwardDiff.Tag{Base.Fix1{typeof(DataInterpolations.derivative), BSplineInterpolation{Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, true, Float64}}, Float64}, Float64, 1})

Closest candidates are:
  (::Type{T})(::Real, ::RoundingMode) where T<:AbstractFloat
   @ Base rounding.jl:207
  (::Type{T})(::T) where T<:Number
   @ Core boot.jl:792
  Float64(::Float32)
   @ Base float.jl:261
  ...
```

This PR should fix it.