### PR TITLE
refactor!: remove indexing dispatches and add dispatch for higher order derivatives with Symbolics

### DIFF
--- a/ext/DataInterpolationsOptimExt.jl
+++ b/ext/DataInterpolationsOptimExt.jl
@@ -31,7 +31,7 @@ function Curvefit(u,
         mfit = optimize(od, lb, ub, p0, Fminbox(alg))
     end
     pmin = Optim.minimizer(mfit)
-    CurvefitCache{true}(u, t, model, p0, ub, lb, alg, pmin, extrapolate)
+    CurvefitCache(u, t, model, p0, ub, lb, alg, pmin, extrapolate)
 end
 
 # Curvefit

--- a/ext/DataInterpolationsRegularizationToolsExt.jl
+++ b/ext/DataInterpolationsRegularizationToolsExt.jl
@@ -75,7 +75,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = LA.diagm(sqrt.(wr))
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u, û, t, t̂, wls, wr, d, λ, alg, Aitp, extrapolate)
+    RegularizationSmooth(u, û, t, t̂, wls, wr, d, λ, alg, Aitp, extrapolate)
 end
 """
 Direct smoothing, no `t̂` or weights
@@ -94,7 +94,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, d::Int = 2;
     Wls½ = Array{Float64}(LA.I, N, N)
     Wr½ = Array{Float64}(LA.I, N - d, N - d)
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,
@@ -121,7 +121,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
     Wls½ = Array{Float64}(LA.I, N, N)
     Wr½ = Array{Float64}(LA.I, N̂ - d, N̂ - d)
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,
@@ -149,7 +149,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = Array{Float64}(LA.I, N̂ - d, N̂ - d)
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,
@@ -179,7 +179,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Nothing
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = Array{Float64}(LA.I, N - d, N - d)
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,
@@ -209,7 +209,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Nothing
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = LA.diagm(sqrt.(wr))
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,
@@ -240,7 +240,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Nothing
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = LA.diagm(sqrt.(wr))
     û, λ, Aitp = _reg_smooth_solve(u, t̂, d, M, Wls½, Wr½, λ, alg, extrapolate)
-    RegularizationSmooth{true}(u,
+    RegularizationSmooth(u,
         û,
         t,
         t̂,

--- a/ext/DataInterpolationsSymbolicsExt.jl
+++ b/ext/DataInterpolationsSymbolicsExt.jl
@@ -21,6 +21,10 @@ function derivative(interp::AbstractInterpolation, t::Num, order = 1)
 end
 SymbolicUtils.promote_symtype(::typeof(derivative), _...) = Real
 
+function Symbolics.derivative(::typeof(derivative), args::NTuple{3, Any}, ::Val{2})
+    Symbolics.unwrap(derivative(args[1], Symbolics.wrap(args[2]), args[3] + 1))
+end
+
 function Symbolics.derivative(interp::AbstractInterpolation, args::NTuple{1, Any}, ::Val{1})
     Symbolics.unwrap(derivative(interp, Symbolics.wrap(args[1])))
 end

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -2,18 +2,7 @@ module DataInterpolations
 
 ### Interface Functionality
 
-abstract type AbstractInterpolation{FT, T} end
-
-Base.size(A::AbstractInterpolation) = size(A.u)
-Base.size(A::AbstractInterpolation{true}) = length(A.u) .+ size(A.t)
-Base.getindex(A::AbstractInterpolation, i) = A.u[i]
-function Base.getindex(A::AbstractInterpolation{true}, i)
-    i <= length(A.u) ? A.u[i] : A.t[i - length(A.u)]
-end
-Base.setindex!(A::AbstractInterpolation, x, i) = A.u[i] = x
-function Base.setindex!(A::AbstractInterpolation{true}, x, i)
-    i <= length(A.u) ? (A.u[i] = x) : (A.t[i - length(A.u)] = x)
-end
+abstract type AbstractInterpolation{T} end
 
 using LinearAlgebra, RecipesBase
 using PrettyTables
@@ -67,7 +56,7 @@ export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation,
 
 # added for RegularizationSmooth, JJS 11/27/21
 ### Regularization data smoothing and interpolation
-struct RegularizationSmooth{uType, tType, FT, T, T2} <: AbstractInterpolation{FT, T}
+struct RegularizationSmooth{uType, tType, T, T2} <: AbstractInterpolation{T}
     u::uType
     û::uType
     t::tType
@@ -77,9 +66,9 @@ struct RegularizationSmooth{uType, tType, FT, T, T2} <: AbstractInterpolation{FT
     d::Int       # derivative degree used to calculate the roughness
     λ::T2        # regularization parameter
     alg::Symbol  # how to determine λ: `:fixed`, `:gcv_svd`, `:gcv_tr`, `L_curve`
-    Aitp::AbstractInterpolation{FT, T}
+    Aitp::AbstractInterpolation{T}
     extrapolate::Bool
-    function RegularizationSmooth{FT}(u,
+    function RegularizationSmooth(u,
             û,
             t,
             t̂,
@@ -89,8 +78,8 @@ struct RegularizationSmooth{uType, tType, FT, T, T2} <: AbstractInterpolation{FT
             λ,
             alg,
             Aitp,
-            extrapolate) where {FT}
-        new{typeof(u), typeof(t), FT, eltype(u), typeof(λ)}(u,
+            extrapolate)
+        new{typeof(u), typeof(t), eltype(u), typeof(λ)}(u,
             û,
             t,
             t̂,
@@ -116,9 +105,8 @@ struct CurvefitCache{
     lbType,
     algType,
     pminType,
-    FT,
     T
-} <: AbstractInterpolation{FT, T}
+} <: AbstractInterpolation{T}
     u::uType
     t::tType
     m::mType        # model type
@@ -128,10 +116,10 @@ struct CurvefitCache{
     alg::algType    # alg to optimize cost function
     pmin::pminType  # optimized params
     extrapolate::Bool
-    function CurvefitCache{FT}(u, t, m, p0, ub, lb, alg, pmin, extrapolate) where {FT}
+    function CurvefitCache(u, t, m, p0, ub, lb, alg, pmin, extrapolate)
         new{typeof(u), typeof(t), typeof(m),
             typeof(p0), typeof(ub), typeof(lb),
-            typeof(alg), typeof(pmin), FT, eltype(u)}(u,
+            typeof(alg), typeof(pmin), eltype(u)}(u,
             t,
             m,
             p0,
@@ -149,8 +137,5 @@ function Curvefit()
 end
 
 export Curvefit
-
-# Deprecated April 2020
-export ZeroSpline
 
 end # module

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -2,7 +2,7 @@ module DataInterpolations
 
 ### Interface Functionality
 
-abstract type AbstractInterpolation{FT, T} <: AbstractVector{T} end
+abstract type AbstractInterpolation{FT, T} end
 
 Base.size(A::AbstractInterpolation) = size(A.u)
 Base.size(A::AbstractInterpolation{true}) = length(A.u) .+ size(A.t)

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -14,7 +14,7 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     if A.t[idx2] == t2
         idx2 -= 1
     end
-    total = zero(eltype(A))
+    total = zero(eltype(A.u))
     for idx in idx1:idx2
         lt1 = idx == idx1 ? t1 : A.t[idx]
         lt2 = idx == idx2 ? t2 : A.t[idx + 1]

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -13,18 +13,18 @@ Extrapolation extends the last linear polynomial on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct LinearInterpolation{uType, tType, FT, T} <: AbstractInterpolation{FT, T}
+struct LinearInterpolation{uType, tType, T} <: AbstractInterpolation{T}
     u::uType
     t::tType
     extrapolate::Bool
-    function LinearInterpolation{FT}(u, t, extrapolate) where {FT}
-        new{typeof(u), typeof(t), FT, eltype(u)}(u, t, extrapolate)
+    function LinearInterpolation(u, t, extrapolate)
+        new{typeof(u), typeof(t), eltype(u)}(u, t, extrapolate)
     end
 end
 
 function LinearInterpolation(u, t; extrapolate = false)
     u, t = munge_data(u, t)
-    LinearInterpolation{true}(u, t, extrapolate)
+    LinearInterpolation(u, t, extrapolate)
 end
 
 """
@@ -43,21 +43,21 @@ Extrapolation extends the last quadratic polynomial on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct QuadraticInterpolation{uType, tType, FT, T} <: AbstractInterpolation{FT, T}
+struct QuadraticInterpolation{uType, tType, T} <: AbstractInterpolation{T}
     u::uType
     t::tType
     mode::Symbol
     extrapolate::Bool
-    function QuadraticInterpolation{FT}(u, t, mode, extrapolate) where {FT}
+    function QuadraticInterpolation(u, t, mode, extrapolate)
         mode ∈ (:Forward, :Backward) ||
             error("mode should be :Forward or :Backward for QuadraticInterpolation")
-        new{typeof(u), typeof(t), FT, eltype(u)}(u, t, mode, extrapolate)
+        new{typeof(u), typeof(t), eltype(u)}(u, t, mode, extrapolate)
     end
 end
 
 function QuadraticInterpolation(u, t, mode; extrapolate = false)
     u, t = munge_data(u, t)
-    QuadraticInterpolation{true}(u, t, mode, extrapolate)
+    QuadraticInterpolation(u, t, mode, extrapolate)
 end
 
 function QuadraticInterpolation(u, t; extrapolate = false)
@@ -79,17 +79,17 @@ It is the method of interpolation using Lagrange polynomials of (k-1)th order pa
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct LagrangeInterpolation{uType, tType, FT, T, bcacheType} <:
-       AbstractInterpolation{FT, T}
+struct LagrangeInterpolation{uType, tType, T, bcacheType} <:
+       AbstractInterpolation{T}
     u::uType
     t::tType
     n::Int
     bcache::bcacheType
     extrapolate::Bool
-    function LagrangeInterpolation{FT}(u, t, n, extrapolate) where {FT}
+    function LagrangeInterpolation(u, t, n, extrapolate)
         bcache = zeros(eltype(u[1]), n + 1)
         fill!(bcache, NaN)
-        new{typeof(u), typeof(t), FT, eltype(u), typeof(bcache)}(u,
+        new{typeof(u), typeof(t), eltype(u), typeof(bcache)}(u,
             t,
             n,
             bcache,
@@ -102,7 +102,7 @@ function LagrangeInterpolation(u, t, n = length(t) - 1; extrapolate = false)
     if n != length(t) - 1
         error("Currently only n=length(t) - 1 is supported")
     end
-    LagrangeInterpolation{true}(u, t, n, extrapolate)
+    LagrangeInterpolation(u, t, n, extrapolate)
 end
 
 """
@@ -120,17 +120,17 @@ Extrapolation extends the last cubic polynomial on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct AkimaInterpolation{uType, tType, bType, cType, dType, FT, T} <:
-       AbstractInterpolation{FT, T}
+struct AkimaInterpolation{uType, tType, bType, cType, dType, T} <:
+       AbstractInterpolation{T}
     u::uType
     t::tType
     b::bType
     c::cType
     d::dType
     extrapolate::Bool
-    function AkimaInterpolation{FT}(u, t, b, c, d, extrapolate) where {FT}
+    function AkimaInterpolation(u, t, b, c, d, extrapolate)
         new{typeof(u), typeof(t), typeof(b), typeof(c),
-            typeof(d), FT, eltype(u)}(u,
+            typeof(d), eltype(u)}(u,
             t,
             b,
             c,
@@ -161,7 +161,7 @@ function AkimaInterpolation(u, t; extrapolate = false)
     c = (3.0 .* m[3:(end - 2)] .- 2.0 .* b[1:(end - 1)] .- b[2:end]) ./ dt
     d = (b[1:(end - 1)] .+ b[2:end] .- 2.0 .* m[3:(end - 2)]) ./ dt .^ 2
 
-    AkimaInterpolation{true}(u, t, b, c, d, extrapolate)
+    AkimaInterpolation(u, t, b, c, d, extrapolate)
 end
 
 """
@@ -181,22 +181,20 @@ Extrapolation extends the last constant polynomial at the end points on each sid
   - `dir`: indicates which value should be used for interpolation (`:left` or `:right`).
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct ConstantInterpolation{uType, tType, dirType, FT, T} <: AbstractInterpolation{FT, T}
+struct ConstantInterpolation{uType, tType, dirType, T} <: AbstractInterpolation{T}
     u::uType
     t::tType
     dir::Symbol # indicates if value to the $dir should be used for the interpolation
     extrapolate::Bool
-    function ConstantInterpolation{FT}(u, t, dir, extrapolate) where {FT}
-        new{typeof(u), typeof(t), typeof(dir), FT, eltype(u)}(u, t, dir, extrapolate)
+    function ConstantInterpolation(u, t, dir, extrapolate)
+        new{typeof(u), typeof(t), typeof(dir), eltype(u)}(u, t, dir, extrapolate)
     end
 end
 
 function ConstantInterpolation(u, t; dir = :left, extrapolate = false)
     u, t = munge_data(u, t)
-    ConstantInterpolation{true}(u, t, dir, extrapolate)
+    ConstantInterpolation(u, t, dir, extrapolate)
 end
-
-Base.@deprecate_binding ZeroSpline ConstantInterpolation
 
 """
     QuadraticSpline(u, t; extrapolate = false)
@@ -213,17 +211,17 @@ Extrapolation extends the last quadratic polynomial on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct QuadraticSpline{uType, tType, tAType, dType, zType, FT, T} <:
-       AbstractInterpolation{FT, T}
+struct QuadraticSpline{uType, tType, tAType, dType, zType, T} <:
+       AbstractInterpolation{T}
     u::uType
     t::tType
     tA::tAType
     d::dType
     z::zType
     extrapolate::Bool
-    function QuadraticSpline{FT}(u, t, tA, d, z, extrapolate) where {FT}
+    function QuadraticSpline(u, t, tA, d, z, extrapolate)
         new{typeof(u), typeof(t), typeof(tA),
-            typeof(d), typeof(z), FT, eltype(u)}(u,
+            typeof(d), typeof(z), eltype(u)}(u,
             t,
             tA,
             d,
@@ -247,7 +245,7 @@ function QuadraticSpline(u::uType,
 
     d = map(i -> i == 1 ? typed_zero : 2 // 1 * (u[i] - u[i - 1]) / (t[i] - t[i - 1]), 1:s)
     z = tA \ d
-    QuadraticSpline{true}(u, t, tA, d, z, extrapolate)
+    QuadraticSpline(u, t, tA, d, z, extrapolate)
 end
 
 function QuadraticSpline(u::uType, t; extrapolate = false) where {uType <: AbstractVector}
@@ -264,7 +262,7 @@ function QuadraticSpline(u::uType, t; extrapolate = false) where {uType <: Abstr
     d = transpose(reshape(reduce(hcat, d_), :, s))
     z_ = reshape(transpose(tA \ d), size(u[1])..., :)
     z = [z_s for z_s in eachslice(z_, dims = ndims(z_))]
-    QuadraticSpline{true}(u, t, tA, d, z, extrapolate)
+    QuadraticSpline(u, t, tA, d, z, extrapolate)
 end
 
 """
@@ -282,14 +280,14 @@ Second derivative on both ends are zero, which are also called "natural" boundar
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct CubicSpline{uType, tType, hType, zType, FT, T} <: AbstractInterpolation{FT, T}
+struct CubicSpline{uType, tType, hType, zType, T} <: AbstractInterpolation{T}
     u::uType
     t::tType
     h::hType
     z::zType
     extrapolate::Bool
-    function CubicSpline{FT}(u, t, h, z, extrapolate) where {FT}
-        new{typeof(u), typeof(t), typeof(h), typeof(z), FT, eltype(u)}(u,
+    function CubicSpline(u, t, h, z, extrapolate)
+        new{typeof(u), typeof(t), typeof(h), typeof(z), eltype(u)}(u,
             t,
             h,
             z,
@@ -317,7 +315,7 @@ function CubicSpline(u::uType,
              6(u[i + 1] - u[i]) / h[i + 1] - 6(u[i] - u[i - 1]) / h[i],
         1:(n + 1))
     z = tA \ d
-    CubicSpline{true}(u, t, h[1:(n + 1)], z, extrapolate)
+    CubicSpline(u, t, h[1:(n + 1)], z, extrapolate)
 end
 
 function CubicSpline(u::uType, t; extrapolate = false) where {uType <: AbstractVector}
@@ -335,7 +333,7 @@ function CubicSpline(u::uType, t; extrapolate = false) where {uType <: AbstractV
     d = transpose(reshape(reduce(hcat, d_), :, n + 1))
     z_ = reshape(transpose(tA \ d), size(u[1])..., :)
     z = [z_s for z_s in eachslice(z_, dims = ndims(z_))]
-    CubicSpline{true}(u, t, h[1:(n + 1)], z, extrapolate)
+    CubicSpline(u, t, h[1:(n + 1)], z, extrapolate)
 end
 
 """
@@ -356,8 +354,8 @@ Extrapolation is a constant polynomial of the end points on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct BSplineInterpolation{uType, tType, pType, kType, cType, FT, T} <:
-       AbstractInterpolation{FT, T}
+struct BSplineInterpolation{uType, tType, pType, kType, cType, T} <:
+       AbstractInterpolation{T}
     u::uType
     t::tType
     d::Int    # degree
@@ -367,7 +365,7 @@ struct BSplineInterpolation{uType, tType, pType, kType, cType, FT, T} <:
     pVecType::Symbol
     knotVecType::Symbol
     extrapolate::Bool
-    function BSplineInterpolation{FT}(u,
+    function BSplineInterpolation(u,
             t,
             d,
             p,
@@ -375,8 +373,8 @@ struct BSplineInterpolation{uType, tType, pType, kType, cType, FT, T} <:
             c,
             pVecType,
             knotVecType,
-            extrapolate) where {FT}
-        new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), FT, eltype(u)}(u,
+            extrapolate)
+        new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), eltype(u)}(u,
             t,
             d,
             p,
@@ -449,7 +447,7 @@ function BSplineInterpolation(u, t, d, pVecType, knotVecType; extrapolate = fals
     # control points
     N = spline_coefficients(n, d, k, p)
     c = vec(N \ u[:, :])
-    BSplineInterpolation{true}(u, t, d, p, k, c, pVecType, knotVecType, extrapolate)
+    BSplineInterpolation(u, t, d, p, k, c, pVecType, knotVecType, extrapolate)
 end
 
 """
@@ -472,8 +470,8 @@ Extrapolation is a constant polynomial of the end points on each side.
 
   - `extrapolate`: boolean value to allow extrapolation. Defaults to `false`.
 """
-struct BSplineApprox{uType, tType, pType, kType, cType, FT, T} <:
-       AbstractInterpolation{FT, T}
+struct BSplineApprox{uType, tType, pType, kType, cType, T} <:
+       AbstractInterpolation{T}
     u::uType
     t::tType
     d::Int    # degree
@@ -484,7 +482,7 @@ struct BSplineApprox{uType, tType, pType, kType, cType, FT, T} <:
     pVecType::Symbol
     knotVecType::Symbol
     extrapolate::Bool
-    function BSplineApprox{FT}(u,
+    function BSplineApprox(u,
             t,
             d,
             h,
@@ -493,8 +491,8 @@ struct BSplineApprox{uType, tType, pType, kType, cType, FT, T} <:
             c,
             pVecType,
             knotVecType,
-            extrapolate) where {FT}
-        new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), FT, eltype(u)}(u,
+            extrapolate)
+        new{typeof(u), typeof(t), typeof(p), typeof(k), typeof(c), eltype(u)}(u,
             t,
             d,
             h,
@@ -590,5 +588,5 @@ function BSplineApprox(u, t, d, h, pVecType, knotVecType; extrapolate = false)
     M = transpose(N) * N
     P = M \ Q
     c[2:(end - 1)] .= vec(P)
-    BSplineApprox{true}(u, t, d, h, p, k, c, pVecType, knotVecType, extrapolate)
+    BSplineApprox(u, t, d, h, p, k, c, pVecType, knotVecType, extrapolate)
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -8,7 +8,7 @@ end
 function _interpolate(A::LinearInterpolation{<:AbstractVector}, t::Number, iguess)
     if isnan(t)
         # For correct derivative with NaN
-        idx = firstindex(A) - 1
+        idx = firstindex(A.u) - 1
         t1 = t2 = one(eltype(A.t))
         u1 = u2 = one(eltype(A.u))
     else

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -4,16 +4,11 @@ t = 1.0collect(1:10)
 A = LinearInterpolation(u, t)
 
 for i in 1:10
-    @test u[i] == A[i]
+    @test u[i] == A.u[i]
 end
 
-for i in 11:20
-    @test t[i - 10] == A[i]
-end
-
-A = LinearInterpolation{false}(u, t, true)
 for i in 1:10
-    @test u[i] == A[i]
+    @test t[i] == A.t[i]
 end
 
 using Symbolics

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -3,7 +3,6 @@ u = 2.0collect(1:10)
 t = 1.0collect(1:10)
 A = LinearInterpolation(u, t)
 
-@test length(A) == 20
 for i in 1:10
     @test u[i] == A[i]
 end
@@ -13,7 +12,6 @@ for i in 11:20
 end
 
 A = LinearInterpolation{false}(u, t, true)
-@test length(A) == 10
 for i in 1:10
     @test u[i] == A[i]
 end

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -6,9 +6,13 @@ u = [0, 1, 0]
 for di in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
     li = di(copy(u), copy(t))
     append!(li, u, t)
-    @test li == di(vcat(u, u), vcat(t, t))
+    li2 = di(vcat(u, u), vcat(t, t))
+    @test li.u == li2.u
+    @test li.t == li2.t
 
     li = di(copy(u), copy(t))
     push!(li, 1, 4)
-    @test li == di(vcat(u, 1), vcat(t, 4))
+    li2 = di(vcat(u, 1), vcat(t, 4))
+    @test li.u == li2.u
+    @test li.t == li2.t
 end


### PR DESCRIPTION
If `AbstractVector` subtyping is not removed, We get errors like:

```julia
julia> df2 = expand_derivatives(D2(f(τ)))
ERROR: Differentiation with array expressions is not yet supported
Stacktrace:
  [1] error(s::String)
    @ Base ./error.jl:35
  [2] occursin_info
    @ ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:67 [inlined]
  [3] (::Symbolics.var"#254#256"{SymbolicUtils.BasicSymbolic{Real}, SymbolicUtils.BasicSymbolic{Real}})(a::LinearInterpolation{Vector{Float64}, Vector{Float64}, true, Float64})
    @ Symbolics ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:100
  [4] iterate
    @ ./generator.jl:47 [inlined]
  [5] _collect(c::Vector{Any}, itr::Base.Generator{Vector{…}, Symbolics.var"#254#256"{…}}, ::Base.EltypeUnknown, isz::Base.HasShape{1})
    @ Base ./array.jl:854
  [6] collect_similar
    @ ./array.jl:763 [inlined]
  [7] map
    @ ./abstractarray.jl:3285 [inlined]
  [8] occursin_info(x::SymbolicUtils.BasicSymbolic{Real}, expr::SymbolicUtils.BasicSymbolic{Real}, fail::Bool)
    @ Symbolics ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:100
  [9] occursin_info(x::SymbolicUtils.BasicSymbolic{Real}, expr::SymbolicUtils.BasicSymbolic{Real})
    @ Symbolics ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:65
 [10] expand_derivatives(O::SymbolicUtils.BasicSymbolic{Real}, simplify::Bool; occurrences::Nothing)
    @ Symbolics ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:177
 [11] expand_derivatives
    @ ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:171 [inlined]
 [12] expand_derivatives(O::SymbolicUtils.BasicSymbolic{Real})
    @ Symbolics ~/.julia/packages/Symbolics/Eas9m/src/diff.jl:171
 [13] top-level scope
    @ REPL[12]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

EDIT: This is indeed breaking.

Also fixes: #240 