### PR TITLE
fix: get element type from `interp.u` instead of  `interp`

### DIFF
--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -22,7 +22,7 @@ include("show.jl")
 (interp::AbstractInterpolation)(t::Number) = _interpolate(interp, t)
 (interp::AbstractInterpolation)(t::Number, i::Integer) = _interpolate(interp, t, i)
 function (interp::AbstractInterpolation)(t::AbstractVector)
-    interp(similar(t, promote_type(eltype(interp), eltype(t))), t)
+    interp(similar(t, promote_type(eltype(interp.u), eltype(t))), t)
 end
 function (interp::AbstractInterpolation)(u::AbstractVector, t::AbstractVector)
     iguess = firstindex(interp.t)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -621,6 +621,21 @@ end
     @test_throws DataInterpolations.ExtrapolationError A(15.0)
 end
 
+@testset "Type of vector returned" begin
+    # Issue https://github.com/SciML/DataInterpolations.jl/issues/253
+    t1 = Float32[0.1, 0.2, 0.3, 0.4, 0.5]
+    t2 = Float64[0.1, 0.2, 0.3, 0.4, 0.5]
+    interps_and_types = [
+        (LinearInterpolation(t1, t1), Float32),
+        (LinearInterpolation(t1, t2), Float32),
+        (LinearInterpolation(t2, t1), Float64),
+        (LinearInterpolation(t2, t2), Float64)
+    ]
+    for i in eachindex(interps_and_types)
+        @test eltype(interps_and_types[i][1](t1)) == interps_and_types[i][2]
+    end
+end
+
 # missing values handling tests
 u = [1.0, 4.0, 9.0, 16.0, 25.0, missing, missing]
 t = [1.0, 2.0, 3.0, 4.0, missing, 6.0, missing]


### PR DESCRIPTION
fixes: #253

In DataInterpolations@v4, `eltype(interp)` returned `eltype(interp.u)` as it subtyped `AbstractVector` of type which is the eltype of `interp.u`

In DataInterpolations@v5, `eltype(interp)` returns `Any` as the subtyping to AbstractVector is removed, hence the issue. Fixing it to use `eltype(interp.u)`.

Added a few tests to ensure the returned vectors have the same type as `interp.u`.
