### PR TITLE
fix: remove abstract type from RegularizationSmooth 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,7 +37,7 @@ Reexport = "1"
 RegularizationTools = "0.6"
 SafeTestsets = "0.1"
 StableRNGs = "1"
-Symbolics = "5.1"
+Symbolics = "5.29"
 Test = "1"
 julia = "1.10"
 

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -56,7 +56,8 @@ export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation,
 
 # added for RegularizationSmooth, JJS 11/27/21
 ### Regularization data smoothing and interpolation
-struct RegularizationSmooth{uType, tType, T, T2, ITP <: AbstractInterpolation{T}} <: AbstractInterpolation{T}
+struct RegularizationSmooth{uType, tType, T, T2, ITP <: AbstractInterpolation{T}} <:
+       AbstractInterpolation{T}
     u::uType
     û::uType
     t::tType

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -56,7 +56,7 @@ export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation,
 
 # added for RegularizationSmooth, JJS 11/27/21
 ### Regularization data smoothing and interpolation
-struct RegularizationSmooth{uType, tType, T, T2} <: AbstractInterpolation{T}
+struct RegularizationSmooth{uType, tType, T, T2, ITP <: AbstractInterpolation{T}} <: AbstractInterpolation{T}
     u::uType
     û::uType
     t::tType
@@ -66,7 +66,7 @@ struct RegularizationSmooth{uType, tType, T, T2} <: AbstractInterpolation{T}
     d::Int       # derivative degree used to calculate the roughness
     λ::T2        # regularization parameter
     alg::Symbol  # how to determine λ: `:fixed`, `:gcv_svd`, `:gcv_tr`, `L_curve`
-    Aitp::AbstractInterpolation{T}
+    Aitp::ITP
     extrapolate::Bool
     function RegularizationSmooth(u,
             û,
@@ -79,7 +79,7 @@ struct RegularizationSmooth{uType, tType, T, T2} <: AbstractInterpolation{T}
             alg,
             Aitp,
             extrapolate)
-        new{typeof(u), typeof(t), eltype(u), typeof(λ)}(u,
+        new{typeof(u), typeof(t), eltype(u), typeof(λ), typeof(Aitp)}(u,
             û,
             t,
             t̂,

--- a/test/regularization.jl
+++ b/test/regularization.jl
@@ -185,3 +185,8 @@ end
     A = RegularizationSmooth(uₒ, tₒ; alg = :fixed)
     @test_throws DataInterpolations.ExtrapolationError A(10.0)
 end
+
+@testset "Type inference" begin
+    A = RegularizationSmooth(uₒ, tₒ; alg = :fixed)
+    @test @inferred(A(1.0)) == A(1.0)
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

fixes #255 by replacing `AbstractInterpolation{T}` with parametric type in the `RegularizationSmooth` struct.

About the style, the modified line is too long, I'm not sure how to split it.
I'm not sure of the name of the parametric type either.
