### PR TITLE
Fix: type instability in interpolator interface

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -122,7 +122,7 @@ function get_idx(tvec, t, iguess; lb = 1, ub_shift = -1, idx_shift = 0, side = :
 end
 
 function cumulative_integral(A)
-    if isempty(methods(_integral, (typeof(A), Any, Any)))
+    if !hasmethod(_integral, Tuple{typeof(A), Number, Number})
         return nothing
     end
     integral_values = [_integral(A, idx, A.t[idx + 1]) - _integral(A, idx, A.t[idx])

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,6 +1,7 @@
 using DataInterpolations
 u = 2.0collect(1:10)
 t = 1.0collect(1:10)
+@inferred LinearInterpolation(u, t)
 A = LinearInterpolation(u, t)
 
 for i in 1:10


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

The interface for, e.g. LinearInterpolation, is not type stable because `cummulative_integral` returns a union. This is because it does a runtime `isempty` check on the methods table. Replacing this with a `hasmethod` check allows the boolean to be determined during compilation, fixing the types.

Note, this does require a slight specialization since `hasmethod` won't match functions that take `::Number` if it's given `Any`.

