### PR TITLE
fix: idxs for derivatives in LinearInterpolation

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -18,7 +18,7 @@ function derivative(A, t, order = 1)
 end
 
 function _derivative(A::LinearInterpolation, t::Number, iguess)
-    idx = get_idx(A.t, t, iguess; idx_shift = -1, ub_shift = -2, side = :first)
+    idx = get_idx(A.t, t, iguess; idx_shift = -1, ub_shift = -1, side = :first)
     A.p.slope[idx], idx
 end
 

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -82,6 +82,12 @@ end
     u = vcat(2.0collect(1:10)', 3.0collect(1:10)')
     test_derivatives(
         LinearInterpolation; args = [u, t], name = "Linear Interpolation (Matrix)")
+
+    # Issue: https://github.com/SciML/DataInterpolations.jl/issues/303
+    u = [3.0, 3.0]
+    t = [0.0, 2.0]
+    test_derivatives(
+        LinearInterpolation; args = [u, t], name = "Linear Interpolation with two points")
 end
 
 @testset "Quadratic Interpolation" begin


### PR DESCRIPTION
fixes: #303 

`ub_shift` should be -1