### PR TITLE
refactor: collect parameters such that they are type stable

### DIFF
--- a/src/online.jl
+++ b/src/online.jl
@@ -68,7 +68,7 @@ function append!(
     append!(A.t.parent, t)
     parameters = quadratic_interpolation_parameters.(
         Ref(A.u), Ref(A.t), (length_old - 1):(length(A.t) - 2))
-    l₀, l₁, l₂ = collect.(eachrow(hcat(collect.(parameters)...)))
+    l₀, l₁, l₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
     append!(A.p.l₀, l₀)
     append!(A.p.l₁, l₁)
     append!(A.p.l₂, l₂)

--- a/src/online.jl
+++ b/src/online.jl
@@ -68,7 +68,7 @@ function append!(
     append!(A.t.parent, t)
     parameters = quadratic_interpolation_parameters.(
         Ref(A.u), Ref(A.t), (length_old - 1):(length(A.t) - 2))
-    l₀, l₁, l₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
+    l₀, l₁, l₂ = collect.(eachrow(stack(collect.(parameters))))
     append!(A.p.l₀, l₀)
     append!(A.p.l₁, l₁)
     append!(A.p.l₂, l₂)

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -24,7 +24,7 @@ end
 function QuadraticParameterCache(u, t)
     parameters = quadratic_interpolation_parameters.(
         Ref(u), Ref(t), 1:(length(t) - 2))
-    l₀, l₁, l₂ = collect.(eachrow(hcat(collect.(parameters)...)))
+    l₀, l₁, l₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
     return QuadraticParameterCache(l₀, l₁, l₂)
 end
 
@@ -72,7 +72,7 @@ end
 function CubicSplineParameterCache(u, h, z)
     parameters = cubic_spline_parameters.(
         Ref(u), Ref(h), Ref(z), 1:(size(u)[end] - 1))
-    c₁, c₂ = collect.(eachrow(hcat(collect.(parameters)...)))
+    c₁, c₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
     return CubicSplineParameterCache(c₁, c₂)
 end
 
@@ -90,7 +90,7 @@ end
 function CubicHermiteParameterCache(du, u, t)
     parameters = cubic_hermite_spline_parameters.(
         Ref(du), Ref(u), Ref(t), 1:(length(t) - 1))
-    c₁, c₂ = collect.(eachrow(hcat(collect.(parameters)...)))
+    c₁, c₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
     return CubicHermiteParameterCache(c₁, c₂)
 end
 
@@ -114,7 +114,7 @@ end
 function QuinticHermiteParameterCache(ddu, du, u, t)
     parameters = quintic_hermite_spline_parameters.(
         Ref(ddu), Ref(du), Ref(u), Ref(t), 1:(length(t) - 1))
-    c₁, c₂, c₃ = collect.(eachrow(hcat(collect.(parameters)...)))
+    c₁, c₂, c₃ = collect.(eachrow(reduce(hcat, collect.(parameters))))
     return QuinticHermiteParameterCache(c₁, c₂, c₃)
 end
 

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -24,7 +24,7 @@ end
 function QuadraticParameterCache(u, t)
     parameters = quadratic_interpolation_parameters.(
         Ref(u), Ref(t), 1:(length(t) - 2))
-    l₀, l₁, l₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
+    l₀, l₁, l₂ = collect.(eachrow(stack(collect.(parameters))))
     return QuadraticParameterCache(l₀, l₁, l₂)
 end
 
@@ -72,7 +72,7 @@ end
 function CubicSplineParameterCache(u, h, z)
     parameters = cubic_spline_parameters.(
         Ref(u), Ref(h), Ref(z), 1:(size(u)[end] - 1))
-    c₁, c₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
+    c₁, c₂ = collect.(eachrow(stack(collect.(parameters))))
     return CubicSplineParameterCache(c₁, c₂)
 end
 
@@ -90,7 +90,7 @@ end
 function CubicHermiteParameterCache(du, u, t)
     parameters = cubic_hermite_spline_parameters.(
         Ref(du), Ref(u), Ref(t), 1:(length(t) - 1))
-    c₁, c₂ = collect.(eachrow(reduce(hcat, collect.(parameters))))
+    c₁, c₂ = collect.(eachrow(stack(collect.(parameters))))
     return CubicHermiteParameterCache(c₁, c₂)
 end
 
@@ -114,7 +114,7 @@ end
 function QuinticHermiteParameterCache(ddu, du, u, t)
     parameters = quintic_hermite_spline_parameters.(
         Ref(ddu), Ref(du), Ref(u), Ref(t), 1:(length(t) - 1))
-    c₁, c₂, c₃ = collect.(eachrow(reduce(hcat, collect.(parameters))))
+    c₁, c₂, c₃ = collect.(eachrow(stack(collect.(parameters))))
     return QuinticHermiteParameterCache(c₁, c₂, c₃)
 end
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,21 +1,52 @@
 using DataInterpolations
-u = 2.0collect(1:10)
-t = 1.0collect(1:10)
-@inferred LinearInterpolation(u, t)
-A = LinearInterpolation(u, t)
-
-for i in 1:10
-    @test u[i] == A.u[i]
-end
-
-for i in 1:10
-    @test t[i] == A.t[i]
-end
-
 using Symbolics
-u = 2.0collect(1:10)
-t = 1.0collect(1:10)
-A = LinearInterpolation(u, t)
 
-@variables t x(t)
-substitute(A(t), Dict(t => x))
+@testset "Interface" begin
+    u = 2.0collect(1:10)
+    t = 1.0collect(1:10)
+    A = LinearInterpolation(u, t)
+
+    for i in 1:10
+        @test u[i] == A.u[i]
+    end
+
+    for i in 1:10
+        @test t[i] == A.t[i]
+    end
+end
+
+@testset "Symbolics" begin
+    u = 2.0collect(1:10)
+    t = 1.0collect(1:10)
+    A = LinearInterpolation(u, t)
+    @variables t x(t)
+    substitute(A(t), Dict(t => x))
+end
+
+@testset "Type Inference" begin
+    u = 2.0collect(1:10)
+    t = 1.0collect(1:10)
+    methods = [
+        ConstantInterpolation, LinearInterpolation,
+        QuadraticInterpolation, LagrangeInterpolation,
+        QuadraticSpline, CubicSpline, AkimaInterpolation
+    ]
+    @testset "$method" for method in methods
+        @inferred method(u, t)
+    end
+    @testset "BSplineInterpolation" begin
+        @inferred BSplineInterpolation(u, t, 3, :Uniform, :Uniform)
+        @inferred BSplineInterpolation(u, t, 3, :ArcLen, :Average)
+    end
+    @testset "BSplineApprox" begin
+        @inferred BSplineApprox(u, t, 3, 5, :Uniform, :Uniform)
+        @inferred BSplineApprox(u, t, 3, 5, :ArcLen, :Average)
+    end
+    du = ones(10)
+    ddu = zeros(10)
+    @testset "Hermite Splines" begin
+        @inferred CubicHermiteSpline(du, u, t)
+        @inferred PCHIPInterpolation(u, t)
+        @inferred QuinticHermiteSpline(ddu, du, u, t)
+    end
+end

--- a/test/online_tests.jl
+++ b/test/online_tests.jl
@@ -9,7 +9,8 @@ u2 = [1.0, 2.0, 1.0]
 ts_append = 1.0:0.5:6.0
 ts_push = 1.0:0.5:4.0
 
-for method in [LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
+@testset "$method" for method in [
+    LinearInterpolation, QuadraticInterpolation, ConstantInterpolation]
     func1 = method(u1, t1)
     append!(func1, u2, t2)
     func2 = method(vcat(u1, u2), vcat(t1, t2))


### PR DESCRIPTION
Followup of #304 - Checked type inference of all methods and found some instabilities like:

```julia
julia> @inferred CubicSpline(u, t)
ERROR: return type CubicSpline{ReadOnlyArrays.ReadOnlyVector{Float64, Vector{Float64}}, ReadOnlyArrays.ReadOnlyVector{Float64, Vector{Float64}}, Vector{Float64}, Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64} does not match inferred return type CubicSpline{ReadOnlyArrays.ReadOnlyVector{Float64, Vector{Float64}}, ReadOnlyArrays.ReadOnlyVector{Float64, Vector{Float64}}, _A, _B, Vector{Float64}, Vector{Float64}, Float64} where {_A, _B}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[6]:1
```

Analyzed using Cthulhu and found instability was in the construction of parameter cache.

I have fixed and added all the inference tests.