### PR TITLE
Bump Zygote compat to 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ StableRNGs = "1"
 Symbolics = "5.29, 6"
 Test = "1.10"
 Unitful = "1.21.1"
-Zygote = "0.6.70"
+Zygote = "0.6.70, 0.7"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
It seems that CompatHelper does not check this one.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
