### PR TITLE
ConstantInterpolation Extrapolation

### DIFF
--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -57,7 +57,7 @@ function _extrapolate_left(A::ConstantInterpolation, t)
     if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        first(A.u)
+        dir == :left ? first(A.u) : A.u[min(2, length(A.u))]
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -68,7 +68,7 @@ function _extrapolate_right(A::ConstantInterpolation, t)
     if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        last(A.u)
+        dir == :left ? A.u[max(1, length(A.u) - 1)] : last(A.u)
     else
         _extrapolate_other(A, t, extrapolation_right)
     end

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -57,7 +57,7 @@ end
 end
 
 @testset "Output Type" begin
-        # Test consistency between eltype(u) and type of the output
+    # Test consistency between eltype(u) and type of the output
     u = Float32[-0.676367f0, 0.8449812f0, 1.2366607f0, -0.13347931f0, 1.9928657f0,
         -0.63596356f0, 0.76009744f0, -0.30632544f0, 0.34649512f0, -0.3846099f0]
     t = 0.1f0:0.1f0:1.0f0


### PR DESCRIPTION
Fixes https://github.com/SciML/DataInterpolations.jl/issues/378

I started working on this but then I found out this was already fxed by @DaniGlez in https://github.com/SciML/DataInterpolations.jl/pull/379, but the issue wasn't closed. I did some nitpicking taking into account the `dir` of the `ConstantInterpolation` and the edgecase that there is only 1 datapoint.

On a more general note, I see that we use `first` and `last` a lot (also in this PR) which only works properly if `u` is a vector (or at least indexed as such). We also have specialized methods for vector versus matrix `u`. To ensure consistency and avoid code duplication, should we define custom indexing functions based on the type of `u`? 