### PR TITLE
Fix type inference and performance problems of `munge_data`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,6 @@ EnumX = "1.0.4"
 FindFirstFunctions = "1.3"
 FiniteDifferences = "0.12.31"
 ForwardDiff = "0.10.36"
-JET = "0.9.17"
 LinearAlgebra = "1.10"
 Optim = "1.6"
 PrettyTables = "2"
@@ -54,7 +53,6 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
@@ -66,4 +64,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "JET", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote"]
+test = ["Aqua", "BenchmarkTools", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,7 @@ EnumX = "1.0.4"
 FindFirstFunctions = "1.3"
 FiniteDifferences = "0.12.31"
 ForwardDiff = "0.10.36"
+JET = "0.9.17"
 LinearAlgebra = "1.10"
 Optim = "1.6"
 PrettyTables = "2"
@@ -53,6 +54,7 @@ BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
@@ -64,4 +66,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote"]
+test = ["Aqua", "BenchmarkTools", "JET", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote"]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -4,7 +4,6 @@ using StableRNGs
 using Optim, ForwardDiff
 using BenchmarkTools
 using Unitful
-using JET
 
 function test_interpolation_type(T)
     @test T <: DataInterpolations.AbstractInterpolation
@@ -925,6 +924,7 @@ f_cubic_spline = c -> square(CubicSpline, c)
 @testset "munge_data" begin
     t0 = [0.1, 0.2, 0.3]
     u0 = ["A", "B", "C"]
+    iszero_allocations(u, t) = iszero(@allocated(DataInterpolations.munge_data(u, t)))
 
     for T in (String, Union{String, Missing}), dims in 1:3
         _u0 = convert(Array{T}, reshape(u0, ntuple(i -> i == dims ? 3 : 1, dims)))
@@ -933,10 +933,9 @@ f_cubic_spline = c -> square(CubicSpline, c)
         @test u isa Array{String, dims}
         @test t isa Vector{Float64}
         if T === String
+            @test iszero_allocations(_u0, t0)
             @test u === _u0
             @test t === t
         end
-
-        @test_call DataInterpolations.munge_data(_u0, t0)
     end
 end

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -4,6 +4,7 @@ using StableRNGs
 using Optim, ForwardDiff
 using BenchmarkTools
 using Unitful
+using JET
 
 function test_interpolation_type(T)
     @test T <: DataInterpolations.AbstractInterpolation
@@ -920,3 +921,22 @@ f_cubic_spline = c -> square(CubicSpline, c)
 @test ForwardDiff.derivative(f_quadratic_spline, 4.0) ≈ 8.0
 @test ForwardDiff.derivative(f_cubic_spline, 2.0) ≈ 4.0
 @test ForwardDiff.derivative(f_cubic_spline, 4.0) ≈ 8.0
+
+@testset "munge_data" begin
+    t0 = [0.1, 0.2, 0.3]
+    u0 = ["A", "B", "C"]
+
+    for T in (String, Union{String, Missing}), dims in 1:3
+        _u0 = convert(Array{T}, reshape(u0, ntuple(i -> i == dims ? 3 : 1, dims)))
+
+        u, t = @inferred(DataInterpolations.munge_data(_u0, t0))
+        @test u isa Array{String, dims}
+        @test t isa Vector{Float64}
+        if T === String
+            @test u === _u0
+            @test t === t
+        end
+
+        @test_call DataInterpolations.munge_data(_u0, t0)
+    end
+end


### PR DESCRIPTION
The PR fixes a few issues related to #389.

On the master branch:

```julia
julia> using DataInterpolations, JET, Chairmarks, Random, Test

julia> @inferred(DataInterpolations.munge_data(["A","B","C"], [0.1,0.2,0.3]))
ERROR: return type Tuple{Vector{String}, Vector{Float64}} does not match inferred return type Tuple{Any, Any}
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:35
 [2] top-level scope
   @ REPL[33]:1

julia> @report_call ConstantInterpolation(["A", "B", "C"], [0.1, 0.2, 0.3])
═════ 2 possible errors found ═════
┌ ConstantInterpolation(u::Vector{String}, t::Vector{Float64}) @ DataInterpolations /Users/david/.julia/packages/DataInterpolations/dFVzN/src/interpolation_caches.jl:353
│┌ ConstantInterpolation(u::Vector{…}, t::Vector{…}; dir::Symbol, extrapolation::DataInterpolations.ExtrapolationType.T, extrapolation_left::DataInterpolations.ExtrapolationType.T, extrapolation_right::DataInterpolations.ExtrapolationType.T, cache_parameters::Bool, assume_linear_t::Float64) @ DataInterpolations /Users/david/.julia/packages/DataInterpolations/dFVzN/src/interpolation_caches.jl:360
││┌ munge_data(u::Vector{String}, t::Vector{Float64}) @ DataInterpolations /Users/david/.julia/packages/DataInterpolations/dFVzN/src/interpolation_utils.jl:120
│││┌ materialize(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, _A, <:Tuple{Vector}} where _A) @ Base.Broadcast ./broadcast.jl:872
││││┌ copy(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{…}, Tuple{…}, _A, <:Tuple{…}} where _A) @ Base.Broadcast ./broadcast.jl:897
│││││┌ copyto!(dest::BitVector, bc::Base.Broadcast.Broadcasted{…} where _A) @ Base.Broadcast ./broadcast.jl:925
││││││┌ copyto!(dest::BitVector, bc::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{…}}, _A, <:Tuple{Vector}} where _A) @ Base.Broadcast ./broadcast.jl:1002
│││││││┌ getindex(::Base.Broadcast.Broadcasted{Nothing, Tuple{…}, _A, <:Tuple{…}} where _A, ::Int64, ::CartesianIndex{0}) @ Base.Broadcast ./broadcast.jl:610
││││││││┌ _broadcast_getindex(bc::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{Int64}}, _A, Union{}} where _A, I::Int64) @ Base.Broadcast ./broadcast.jl:669
│││││││││┌ getproperty(x::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{Int64}}, _A, Union{}} where _A, f::Symbol) @ Base ./Base.jl:49
││││││││││ invalid builtin function call: Base.getfield(x::Base.Broadcast.Broadcasted{Nothing, Tuple{Base.OneTo{Int64}}, _A, Union{}} where _A, f::Symbol)
│││││││││└────────────────────
││││┌ copy(bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{…}, Tuple{…}, _A, <:Tuple{…}} where _A) @ Base.Broadcast ./broadcast.jl:911
│││││┌ getindex(bc::Base.Broadcast.Broadcasted{…} where _A, Is::Int64) @ Base.Broadcast ./broadcast.jl:610
││││││┌ _broadcast_getindex(bc::Base.Broadcast.Broadcasted{…} where _A, I::Int64) @ Base.Broadcast ./broadcast.jl:669
│││││││┌ getproperty(x::Base.Broadcast.Broadcasted{…} where _A, f::Symbol) @ Base ./Base.jl:49
││││││││ invalid builtin function call: Base.getfield(x::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Tuple{Base.OneTo{Int64}}, _A, Union{}} where _A, f::Symbol)
│││││││└────────────────────


julia> @b ([randstring(3) for _ in 1:100],rand(100)) DataInterpolations.munge_data(_[1], _[2])
7.938 μs (230 allocs: 9.188 KiB)

julia> @code_warntype ConstantInterpolation(["A", "B", "C"], [0.1, 0.2, 0.3])
MethodInstance for ConstantInterpolation(::Vector{String}, ::Vector{Float64})
  from ConstantInterpolation(u, t; dir, extrapolation, extrapolation_left, extrapolation_right, cache_parameters, assume_linear_t) @ DataInterpolations ~/.julia/packages/DataInterpolations/dFVzN/src/interpolation_caches.jl:353
Arguments
  #self#::Type{ConstantInterpolation}
  u::Vector{String}
  t::Vector{Float64}
Body::ConstantInterpolation
1 ─ %1 = DataInterpolations.:(var"#ConstantInterpolation#6")::Core.Const(DataInterpolations.var"#ConstantInterpolation#6")
│   %2 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %3 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %4 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %5 = (%1)(:left, %2, %3, %4, false, 0.01, #self#, u, t)::ConstantInterpolation
└──      return %5
```

With this PR:

```julia
julia> using DataInterpolations, JET, Chairmarks, Random, Test

julia> @inferred(DataInterpolations.munge_data(["A","B","C"], [0.1,0.2,0.3]))
(["A", "B", "C"], [0.1, 0.2, 0.3])

julia> @report_call ConstantInterpolation(["A", "B", "C"], [0.1, 0.2, 0.3])
No errors detected

julia> @report_call ConstantInterpolation(["A";; "B";; "C"], [0.1, 0.2, 0.3])
No errors detected

julia> @report_call ConstantInterpolation(["A";;; "B";;; "C"], [0.1, 0.2, 0.3])
No errors detected

julia> @b ([randstring(3) for _ in 1:100],rand(100)) DataInterpolations.munge_data(_[1], _[2])
1.993 ns

julia> @code_warntype ConstantInterpolation(["A", "B", "C"], [0.1, 0.2, 0.3])
MethodInstance for ConstantInterpolation(::Vector{String}, ::Vector{Float64})
  from ConstantInterpolation(u, t; dir, extrapolation, extrapolation_left, extrapolation_right, cache_parameters, assume_linear_t) @ DataInterpolations ~/.julia/dev/DataInterpolations/src/interpolation_caches.jl:353
Arguments
  #self#::Type{ConstantInterpolation}
  u::Vector{String}
  t::Vector{Float64}
Body::ConstantInterpolation{Vector{String}, Vector{Float64}, _A, String} where _A
1 ─ %1 = DataInterpolations.:(var"#ConstantInterpolation#6")::Core.Const(DataInterpolations.var"#ConstantInterpolation#6")
│   %2 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %3 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %4 = DataInterpolations.ExtrapolationType.None::Core.Const(DataInterpolations.ExtrapolationType.None)
│   %5 = (%1)(:left, %2, %3, %4, false, 0.01, #self#, u, t)::ConstantInterpolation{Vector{String}, Vector{Float64}, _A, String} where _A
└──      return %5
```