### PR TITLE
Ensure that the interpolation domain is sorted

### DIFF
--- a/ext/DataInterpolationsRegularizationToolsExt.jl
+++ b/ext/DataInterpolationsRegularizationToolsExt.jl
@@ -76,7 +76,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = ("third", "t̂"))
     M = _mapping_matrix(t̂, t)
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = LA.diagm(sqrt.(wr))
@@ -139,7 +139,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = ("third", "t̂"))
     N, N̂ = length(t), length(t̂)
     M = _mapping_matrix(t̂, t)
     Wls½ = Array{Float64}(LA.I, N, N)
@@ -176,7 +176,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = ("third", "t̂"))
     N, N̂ = length(t), length(t̂)
     M = _mapping_matrix(t̂, t)
     Wls½ = LA.diagm(sqrt.(wls))

--- a/ext/DataInterpolationsRegularizationToolsExt.jl
+++ b/ext/DataInterpolationsRegularizationToolsExt.jl
@@ -76,7 +76,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t)
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
     M = _mapping_matrix(t̂, t)
     Wls½ = LA.diagm(sqrt.(wls))
     Wr½ = LA.diagm(sqrt.(wr))
@@ -139,7 +139,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t)
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
     N, N̂ = length(t), length(t̂)
     M = _mapping_matrix(t̂, t)
     Wls½ = Array{Float64}(LA.I, N, N)
@@ -176,7 +176,7 @@ function RegularizationSmooth(u::AbstractVector, t::AbstractVector, t̂::Abstrac
         cache_parameters::Bool = false)
     extrapolation_left, extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
-    u, t = munge_data(u, t)
+    u, t = munge_data(u, t; check_sorted = t̂, sorted_arg_name = "third")
     N, N̂ = length(t), length(t̂)
     M = _mapping_matrix(t̂, t)
     Wls½ = LA.diagm(sqrt.(wls))

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -91,14 +91,15 @@ function quadratic_spline_params(t::AbstractVector, sc::AbstractVector)
 end
 
 # helper function for data manipulation
-function munge_data(u::AbstractVector, t::AbstractVector)
+function munge_data(u::AbstractVector, t::AbstractVector;
+        check_sorted = t, sorted_arg_name = "second")
     Tu = nonmissingtype(eltype(u))
     Tt = nonmissingtype(eltype(t))
 
     if Tu === eltype(u) && Tt === eltype(t)
-        if !(issorted(t) || issorted(t, rev = true))
+        if !(issorted(check_sorted) || issorted(check_sorted, rev = true))
             # there is likely an user error
-            msg = "The second argument, which is used for the interpolation domain, is not sorted."
+            msg = "The $sorted_arg_name argument, which is used for the interpolation domain, is not sorted."
             if (issorted(u) || issorted(u, rev = true))
                 msg *= "\nIt looks like the arguments were inversed, make sure you used the arguments in the correct order."
             end

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -92,16 +92,16 @@ end
 
 # helper function for data manipulation
 function munge_data(u::AbstractVector, t::AbstractVector;
-        check_sorted = t, sorted_arg_name = "second")
+        check_sorted = t, sorted_arg_name = ("second", "t"))
     Tu = nonmissingtype(eltype(u))
     Tt = nonmissingtype(eltype(t))
 
     if Tu === eltype(u) && Tt === eltype(t)
         if !(issorted(check_sorted) || issorted(check_sorted, rev = true))
             # there is likely an user error
-            msg = "The $sorted_arg_name argument, which is used for the interpolation domain, is not sorted."
-            if (issorted(u) || issorted(u, rev = true))
-                msg *= "\nIt looks like the arguments were inversed, make sure you used the arguments in the correct order."
+            msg = "The $(sorted_arg_name[1]) argument (`$(sorted_arg_name[2])`), which is used for the interpolation domain, is not sorted."
+            if (issorted(u))
+                msg *= "\nIt looks like the arguments `u` and `$(sorted_arg_name[2])` were inversed, make sure you used the arguments in the correct order."
             end
             throw(ArgumentError(msg))
         end

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -94,11 +94,22 @@ end
 function munge_data(u::AbstractVector, t::AbstractVector)
     Tu = nonmissingtype(eltype(u))
     Tt = nonmissingtype(eltype(t))
+
     if Tu === eltype(u) && Tt === eltype(t)
+        if !(issorted(t) || issorted(t, rev = true))
+            # there is likely an user error
+            msg = "The second argument, which is used for the interpolation domain, is not sorted."
+            if (issorted(u) || issorted(u, rev = true))
+                msg *= "\nIt looks like the arguments were inversed, make sure you used the arguments in the correct order."
+            end
+            throw(ArgumentError(msg))
+        end
+
         return u, t
     end
 
     @assert length(t) == length(u)
+
     non_missing_mask = map((ui, ti) -> !ismissing(ui) && !ismissing(ti), u, t)
     u = convert(AbstractVector{Tu}, u[non_missing_mask])
     t = convert(AbstractVector{Tt}, t[non_missing_mask])

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -97,10 +97,10 @@ function munge_data(u::AbstractVector, t::AbstractVector;
     Tt = nonmissingtype(eltype(t))
 
     if Tu === eltype(u) && Tt === eltype(t)
-        if !(issorted(check_sorted) || issorted(check_sorted, rev = true))
+        if !issorted(check_sorted)
             # there is likely an user error
             msg = "The $(sorted_arg_name[1]) argument (`$(sorted_arg_name[2])`), which is used for the interpolation domain, is not sorted."
-            if (issorted(u))
+            if issorted(u)
                 msg *= "\nIt looks like the arguments `u` and `$(sorted_arg_name[2])` were inversed, make sure you used the arguments in the correct order."
             end
             throw(ArgumentError(msg))

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1105,3 +1105,8 @@ f_cubic_spline = c -> square(CubicSpline, c)
         end
     end
 end
+
+@testset "user error" begin
+    @test_throws ArgumentError LinearInterpolation(rand(10), rand(10))
+    @test_throws ArgumentError LinearInterpolation(0:10, rand(10))
+end

--- a/test/regularization.jl
+++ b/test/regularization.jl
@@ -191,3 +191,10 @@ end
     A = RegularizationSmooth(uₒ, tₒ; alg = :fixed)
     @test @inferred(A(1.0)) == A(1.0)
 end
+
+@testset "User error" begin
+    @test_throws ArgumentError RegularizationSmooth(tₒ, uₒ; alg = :fixed)
+    N̂ = 20
+    t̂ = collect(range(xmin, xmin + xspan, length = N̂))
+    @test_throws ArgumentError RegularizationSmooth(u, t̂, t)
+end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

A frequent user error is forgetting the correct argument error. This results in silently wrong results or extrapolation errors. I think that we can surface this error earlier to avoid further confusion. Let me know what you think about this.