### PR TITLE
Fix `get_transition_ts`

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -392,18 +392,17 @@ function smooth_arc_length_params_2(u_int, uⱼ, uⱼ₊₁)
 end
 
 function get_transition_ts(A::SmoothedConstantInterpolation)
-    out = similar(A.t, 3 * length(A.t))
+    out = similar(A.t, 3 * length(A.t) - 2)
 
     for idx in 1:(length(A.t) - 1)
         d_lower, d_upper, _, _ = get_parameters(A, idx)
         if idx == 1
             out[1] = A.t[1]
-            out[2] = A.t[1]
-            out[3] = A.t[1] + d_lower
+            out[2] = A.t[1] + d_lower
         else
-            out[3idx - 2] = A.t[idx] - d_upper
-            out[3idx - 1] = A.t[idx]
-            out[3idx] = A.t[idx] + d_lower
+            out[3idx - 3] = A.t[idx] - d_upper
+            out[3idx - 2] = A.t[idx]
+            out[3idx - 1] = A.t[idx] + d_lower
         end
     end
 

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -627,6 +627,8 @@ end
     A = SmoothedConstantInterpolation(u, t; d_max)
     test_cached_index(A)
 
+    @test DataInterpolations.get_transition_ts(A) == [
+        1.2, 1.7, 2.0, 2.5, 3.0, 5.2, 5.7, 6.2, 8.2, 8.7]
     @test A(1.9) == u[1]
     @test A(3.1) == u[2]
     @test A(2.5) ≈ (u[1] + u[2]) / 2


### PR DESCRIPTION
Turns out this contained an uninitialized value.
