### PR TITLE
Add optional extrapolation methods

### DIFF
--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -41,9 +41,10 @@ struct LinearInterpolationIntInv{uType, tType, itpType, T} <:
     extrapolation_right::ExtrapolationType.T
     iguesser::Guesser{tType}
     itp::itpType
-    function LinearInterpolationIntInv(u, t, A)
+    function LinearInterpolationIntInv(u, t, A, extrapolation_left = A.extrapolation_left,
+            extrapolation_right = A.extrapolation_right)
         new{typeof(u), typeof(t), typeof(A), eltype(u)}(
-            u, t, A.extrapolation_left, A.extrapolation_right, Guesser(t), A)
+            u, t, extrapolation_left, extrapolation_right, Guesser(t), A)
     end
 end
 
@@ -57,9 +58,13 @@ function get_I(A::AbstractInterpolation)
     I
 end
 
-function invert_integral(A::LinearInterpolation{<:AbstractVector{<:Number}})
+function invert_integral(A::LinearInterpolation{<:AbstractVector{<:Number}},
+        extrapolation_left::ExtrapolationType.T = A.extrapolation_left,
+        extrapolation_right::ExtrapolationType.T = A.extrapolation_right)
     !invertible_integral(A) && throw(IntegralNotInvertibleError())
-    return LinearInterpolationIntInv(A.t, get_I(A), A)
+
+    return LinearInterpolationIntInv(
+        A.t, get_I(A), A, extrapolation_left, extrapolation_right)
 end
 
 function _interpolate(
@@ -92,9 +97,11 @@ struct ConstantInterpolationIntInv{uType, tType, itpType, T} <:
     extrapolation_right::ExtrapolationType.T
     iguesser::Guesser{tType}
     itp::itpType
-    function ConstantInterpolationIntInv(u, t, A)
+    function ConstantInterpolationIntInv(
+            u, t, A, extrapolation_left = A.extrapolation_left,
+            extrapolation_right = A.extrapolation_right)
         new{typeof(u), typeof(t), typeof(A), eltype(u)}(
-            u, t, A.extrapolation_left, A.extrapolation_right, Guesser(t), A
+            u, t, extrapolation_left, extrapolation_right, Guesser(t), A
         )
     end
 end
@@ -103,9 +110,12 @@ function invertible_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}
     return all(A.u .> 0)
 end
 
-function invert_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}})
+function invert_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}},
+        extrapolation_left::ExtrapolationType.T = A.extrapolation_left,
+        extrapolation_right::ExtrapolationType.T = A.extrapolation_right)
     !invertible_integral(A) && throw(IntegralNotInvertibleError())
-    return ConstantInterpolationIntInv(A.t, get_I(A), A)
+    return ConstantInterpolationIntInv(
+        A.t, get_I(A), A, extrapolation_left, extrapolation_right)
 end
 
 function _interpolate(

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -41,8 +41,7 @@ struct LinearInterpolationIntInv{uType, tType, itpType, T} <:
     extrapolation_right::ExtrapolationType.T
     iguesser::Guesser{tType}
     itp::itpType
-    function LinearInterpolationIntInv(u, t, A, extrapolation_left,
-            extrapolation_right)
+    function LinearInterpolationIntInv(u, t, A, extrapolation_left, extrapolation_right)
         new{typeof(u), typeof(t), typeof(A), eltype(u)}(
             u, t, extrapolation_left, extrapolation_right, Guesser(t), A)
     end

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -58,7 +58,7 @@ function get_I(A::AbstractInterpolation)
 end
 
 function invert_integral(
-        A::LinearInterpolation{<:AbstractVector{<:Number}},
+        A::LinearInterpolation{<:AbstractVector{<:Number}};
         extrapolation_left::ExtrapolationType.T = A.extrapolation_left,
         extrapolation_right::ExtrapolationType.T = A.extrapolation_right)
     !invertible_integral(A) && throw(IntegralNotInvertibleError())
@@ -109,7 +109,7 @@ function invertible_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}
     return all(A.u .> 0)
 end
 
-function invert_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}},
+function invert_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}};
         extrapolation_left::ExtrapolationType.T = A.extrapolation_left,
         extrapolation_right::ExtrapolationType.T = A.extrapolation_right)
     !invertible_integral(A) && throw(IntegralNotInvertibleError())

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -57,7 +57,8 @@ function get_I(A::AbstractInterpolation)
     I
 end
 
-function invert_integral(A::LinearInterpolation{<:AbstractVector{<:Number}},
+function invert_integral(
+        A::LinearInterpolation{<:AbstractVector{<:Number}},
         extrapolation_left::ExtrapolationType.T = A.extrapolation_left,
         extrapolation_right::ExtrapolationType.T = A.extrapolation_right)
     !invertible_integral(A) && throw(IntegralNotInvertibleError())

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -41,8 +41,8 @@ struct LinearInterpolationIntInv{uType, tType, itpType, T} <:
     extrapolation_right::ExtrapolationType.T
     iguesser::Guesser{tType}
     itp::itpType
-    function LinearInterpolationIntInv(u, t, A, extrapolation_left = A.extrapolation_left,
-            extrapolation_right = A.extrapolation_right)
+    function LinearInterpolationIntInv(u, t, A, extrapolation_left,
+            extrapolation_right)
         new{typeof(u), typeof(t), typeof(A), eltype(u)}(
             u, t, extrapolation_left, extrapolation_right, Guesser(t), A)
     end
@@ -98,8 +98,7 @@ struct ConstantInterpolationIntInv{uType, tType, itpType, T} <:
     iguesser::Guesser{tType}
     itp::itpType
     function ConstantInterpolationIntInv(
-            u, t, A, extrapolation_left = A.extrapolation_left,
-            extrapolation_right = A.extrapolation_right)
+            u, t, A, extrapolation_left, extrapolation_right)
         new{typeof(u), typeof(t), typeof(A), eltype(u)}(
             u, t, extrapolation_left, extrapolation_right, Guesser(t), A
         )

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -1220,8 +1220,8 @@ function BSplineApprox(
     end
     for k in 2:(n - 1)
         q[ax_u...,
-        k] = u[ax_u..., k] - sc[k, 1] * u[ax_u..., 1] -
-             sc[k, h] * u[ax_u..., end]
+            k] = u[ax_u..., k] - sc[k, 1] * u[ax_u..., 1] -
+                 sc[k, h] * u[ax_u..., end]
     end
     Q = Array{T, N}(undef, size(u)[1:(end - 1)]..., h - 2)
     for i in 2:(h - 1)

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -191,7 +191,8 @@ function cumulative_integral(A::AbstractInterpolation{<:Number}, cache_parameter
     Base.require_one_based_indexing(A.u)
     idxs = cache_parameters ? (1:(length(A.t) - 1)) : (1:0)
     return cumsum(_integral(A, idx, t1, t2)
-    for (idx, t1, t2) in zip(idxs, @view(A.t[begin:(end - 1)]), @view(A.t[(begin + 1):end])))
+    for (idx, t1, t2) in
+        zip(idxs, @view(A.t[begin:(end - 1)]), @view(A.t[(begin + 1):end])))
 end
 
 function get_parameters(A::LinearInterpolation, idx)

--- a/test/integral_inverse_tests.jl
+++ b/test/integral_inverse_tests.jl
@@ -1,5 +1,6 @@
 using DataInterpolations
 using DataInterpolations: integral, derivative, invert_integral
+using FiniteDifferences
 
 function test_integral_inverses(method; args = [], kwargs = [])
     A = method(args...; kwargs..., extrapolation = ExtrapolationType.Extension)
@@ -22,17 +23,19 @@ end
 
 function test_integral_inverse_extrapolation()
     # Linear function with constant extrapolation
-    t = collect(0:4)
-    u = [0.0, 2.0, 3.0, 4.0]
+    t = collect(1:4)
+    u = [1.0, 2.0, 3.0, 4.0]
     A = LinearInterpolation(u, t, extrapolation = ExtrapolationType.Constant)
 
-    A_intinv = invert_integral(A, extrapolation_left = ExtrapolationType.Extension,
-        extrapolation_right = ExtrapolationType.Extension)
+    A_intinv = invert_integral(A, ExtrapolationType.Extension, ExtrapolationType.Extension)
 
     # for a linear function, the integral is quadratic
     # but the constant extrapolation part is linear.
-    A_5 = 1 / 2 * 4.0^2 + 5.0
-    @test A_int_inv(A_5) ≈ 5.0
+    area_0_to_4 = 0.5 * 4.0^2
+    area_4_to_5 = 4.0
+    area = area_0_to_4 + area_4_to_5
+
+    @test A_intinv(area) ≈ 5.0
 end
 
 @testset "Linear Interpolation" begin

--- a/test/integral_inverse_tests.jl
+++ b/test/integral_inverse_tests.jl
@@ -38,6 +38,21 @@ function test_integral_inverse_extrapolation()
     @test A_intinv(area) ≈ 5.0
 end
 
+function test_integral_inverse_const_extrapolation()
+    # Constant function with constant extrapolation
+    t = collect(1:4)
+    u = [1.0, 1.0, 1.0, 1.0]
+    A = ConstantInterpolation(u, t, extrapolation = ExtrapolationType.Extension)
+
+    A_intinv = invert_integral(A, ExtrapolationType.Extension, ExtrapolationType.Extension)
+
+    area_0_to_4 = 1.0 * (4.0 - 1.0)
+    area_4_to_5 = 1.0
+    area = area_0_to_4 + area_4_to_5
+
+    @test A_intinv(area) ≈ 5.0
+end
+
 @testset "Linear Interpolation" begin
     t = collect(1:5)
     u = [1.0, 1.0, 2.0, 4.0, 3.0]
@@ -59,6 +74,8 @@ end
     u = [1.0, -1.0, 2.0, 4.0, 3.0]
     A = ConstantInterpolation(u, t)
     @test_throws DataInterpolations.IntegralNotInvertibleError invert_integral(A)
+
+    test_integral_inverse_const_extrapolation()
 end
 
 t = collect(1:5)

--- a/test/integral_inverse_tests.jl
+++ b/test/integral_inverse_tests.jl
@@ -1,6 +1,5 @@
 using DataInterpolations
 using DataInterpolations: integral, derivative, invert_integral
-using FiniteDifferences
 
 function test_integral_inverses(method; args = [], kwargs = [])
     A = method(args...; kwargs..., extrapolation = ExtrapolationType.Extension)
@@ -21,6 +20,21 @@ function test_integral_inverses(method; args = [], kwargs = [])
     @test @inferred(A(ts[37])) == A(ts[37])
 end
 
+function test_integral_inverse_extrapolation()
+    # Linear function with constant extrapolation
+    t = collect(0:4)
+    u = [0.0, 2.0, 3.0, 4.0]
+    A = LinearInterpolation(u, t, extrapolation = ExtrapolationType.Constant)
+
+    A_intinv = invert_integral(A, extrapolation_left = ExtrapolationType.Extension,
+        extrapolation_right = ExtrapolationType.Extension)
+
+    # for a linear function, the integral is quadratic
+    # but the constant extrapolation part is linear.
+    A_5 = 1 / 2 * 4.0^2 + 5.0
+    @test A_int_inv(A_5) ≈ 5.0
+end
+
 @testset "Linear Interpolation" begin
     t = collect(1:5)
     u = [1.0, 1.0, 2.0, 4.0, 3.0]
@@ -29,6 +43,8 @@ end
     u = [1.0, -1.0, 2.0, 4.0, 3.0]
     A = LinearInterpolation(u, t)
     @test_throws DataInterpolations.IntegralNotInvertibleError invert_integral(A)
+
+    test_integral_inverse_extrapolation()
 end
 
 @testset "Constant Interpolation" begin

--- a/test/integral_inverse_tests.jl
+++ b/test/integral_inverse_tests.jl
@@ -27,7 +27,8 @@ function test_integral_inverse_extrapolation()
     u = [1.0, 2.0, 3.0, 4.0]
     A = LinearInterpolation(u, t, extrapolation = ExtrapolationType.Constant)
 
-    A_intinv = invert_integral(A, ExtrapolationType.Extension, ExtrapolationType.Extension)
+    A_intinv = invert_integral(A, extrapolation_left = ExtrapolationType.Extension,
+        extrapolation_right = ExtrapolationType.Extension)
 
     # for a linear function, the integral is quadratic
     # but the constant extrapolation part is linear.
@@ -44,7 +45,8 @@ function test_integral_inverse_const_extrapolation()
     u = [1.0, 1.0, 1.0, 1.0]
     A = ConstantInterpolation(u, t, extrapolation = ExtrapolationType.Extension)
 
-    A_intinv = invert_integral(A, ExtrapolationType.Extension, ExtrapolationType.Extension)
+    A_intinv = invert_integral(A, extrapolation_left = ExtrapolationType.Extension,
+        extrapolation_right = ExtrapolationType.Extension)
 
     area_0_to_4 = 1.0 * (4.0 - 1.0)
     area_4_to_5 = 1.0

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1027,6 +1027,7 @@ end
     ut1 = Float32[0.1, 0.2, 0.3, 0.4, 0.5]
     ut2 = Float64[0.1, 0.2, 0.3, 0.4, 0.5]
     for u in (ut1, ut2), t in (ut1, ut2)
+
         interp = @inferred(LinearInterpolation(ut1, ut2))
         for xs in (u, t)
             ys = @inferred(interp(xs))
@@ -1109,6 +1110,7 @@ f_cubic_spline = c -> square(CubicSpline, c)
     iszero_allocations(u, t) = iszero(@allocated(DataInterpolations.munge_data(u, t)))
 
     for T in (String, Union{String, Missing}), dims in 1:3
+
         _u0 = convert(Array{T}, reshape(u0, ntuple(i -> i == dims ? 3 : 1, dims)))
 
         u, t = @inferred(DataInterpolations.munge_data(_u0, t0))


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Before, invert_integral inherits the extrapolation method from the interpolation it got in its construction. 
If we did a piecewise linear interpolation with constant extrapolation, the inverted integral would not integrate beyond the input data. With this change, we can set the extrapolation method of invert_integral independent of the interpolation.
