### PR TITLE
Convert `z` in `CubicSpline` for performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,6 +30,7 @@ DataInterpolationsSymbolicsExt = "Symbolics"
 DataInterpolationsMakieExt = "Makie"
 
 [compat]
+AllocCheck = "0.2"
 Aqua = "0.8"
 BenchmarkTools = "1"
 ChainRulesCore = "1.25"
@@ -49,6 +50,7 @@ RegularizationTools = "0.6"
 SafeTestsets = "0.1"
 SparseConnectivityTracer = "1"
 StableRNGs = "1"
+StaticArrays = "1.9"
 Symbolics = "6.46"
 Test = "1.10"
 Unitful = "1.21.1"
@@ -56,6 +58,7 @@ Zygote = "0.6.77, 0.7"
 julia = "1.10"
 
 [extras]
+AllocCheck = "9b6a8646-10ed-4001-bbdc-1d2f46dfbb1a"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -68,10 +71,11 @@ RegularizationTools = "29dad682-9a27-4bc3-9c72-016788665182"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote", "SparseConnectivityTracer"]
+test = ["Aqua", "AllocCheck", "BenchmarkTools", "SafeTestsets", "ChainRulesCore", "Optim", "RegularizationTools", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "StaticArrays", "Symbolics", "Unitful", "Zygote", "SparseConnectivityTracer"]

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -719,7 +719,7 @@ function CubicSpline(
         1:(n + 1))
     d = transpose(reshape(reduce(hcat, d_), :, n + 1))
     z_ = reshape(transpose(tA \ d), size(u[1])..., :)
-    z = [z_s for z_s in eachslice(z_, dims = ndims(z_))]
+    z = [convert(eltype(u), z_s) for z_s in eachslice(z_, dims = ndims(z_))]
 
     p = CubicSplineParameterCache(u, h, z, cache_parameters)
     A = CubicSpline(

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -1463,7 +1463,7 @@ end
         interpolation_type::Type{<:AbstractInterpolation} = QuadraticSpline,
         kwargs...) where {U}
 
-Interpolate in a C¹ smooth way trough the data with unit speed by approximating
+Interpolate in a C¹ smooth way through the data with unit speed by approximating
 an interpolation (the shape interpolation) with line segments and circle segments.
 
 ## Arguments

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -361,7 +361,7 @@ end
 
 # Quintic Hermite Spline
 function _interpolate(
-        A::QuinticHermiteSpline{<:AbstractVector{<:Number}}, t::Number, iguess)
+        A::QuinticHermiteSpline{<:AbstractVector}, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt₀ = t - A.t[idx]
     Δt₁ = t - A.t[idx + 1]

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -349,7 +349,7 @@ end
 
 # Cubic Hermite Spline
 function _interpolate(
-        A::CubicHermiteSpline{<:AbstractVector{<:Number}}, t::Number, iguess)
+        A::CubicHermiteSpline{<:AbstractVector}, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt₀ = t - A.t[idx]
     Δt₁ = t - A.t[idx + 1]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -932,6 +932,19 @@ end
     test_cached_index(A)
     push!(u, 1.0)
     @test_throws AssertionError CubicHermiteSpline(du, u, t)
+
+    @testset "Vector of Vectors case" begin
+        u2 = [[u[i], u[i] + 1] for i in eachindex(u)]
+        du2 = [[du[i], du[i]] for i in eachindex(du)]
+        A2 = CubicHermiteSpline(du2, u2, t)
+        @test u2 ≈ A2.(t)
+    end
+    @testset "Vector of Matrices case" begin
+        u3 = [[u[i] u[i] + 1] for i in eachindex(u)]
+        du3 = [[du[i] du[i]] for i in eachindex(du)]
+        A3 = CubicHermiteSpline(du3, u3, t)
+        @test u3 ≈ A3.(t)
+    end
 end
 
 @testset "PCHIPInterpolation" begin

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -88,9 +88,8 @@ end
         # Test allocation-free interpolation with StaticArrays
         u_s = [convert(SVector{length(y), eltype(u_)}, i) for i in u]
         @test @inferred(LinearInterpolation(
-            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation broken=true &&
-                                                                                               t isa
-                                                                                               AbstractRange
+            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation
+         @test t isa AbstractRange
         A_s = LinearInterpolation(u_s, t; extrapolation = ExtrapolationType.Extension)
         for _x in (0, 5.5, 11)
             @test A(x) == A_s(x)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -980,6 +980,21 @@ end
     @test_throws AssertionError QuinticHermiteSpline(ddu, du, u, t)
     @test @inferred(output_dim(A)) == 0
     @test @inferred(output_size(A)) == ()
+
+    @testset "Vector of Vectors case" begin
+        u2 = [[u[i], u[i] + 1] for i in eachindex(u)]
+        du2 = [[du[i], du[i]] for i in eachindex(du)]
+        ddu2 = [[ddu[i], ddu[i]] for i in eachindex(ddu)]
+        A2 = QuinticHermiteSpline(ddu2, du2, u2, t)
+        @test u2 ≈ A2.(t)
+    end
+    @testset "Vector of Matrices case" begin
+        u3 = [[u[i] u[i] + 1] for i in eachindex(u)]
+        du3 = [[du[i] du[i]] for i in eachindex(du)]
+        ddu3 = [[ddu[i] ddu[i]] for i in eachindex(ddu)]
+        A3 = QuinticHermiteSpline(ddu3, du3, u3, t)
+        @test u3 ≈ A3.(t)
+    end
 end
 
 @testset "Smooth Arc Length Interpolation" begin

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -88,8 +88,7 @@ end
         # Test allocation-free interpolation with StaticArrays
         u_s = [convert(SVector{length(y), eltype(u_)}, i) for i in u]
         @test @inferred(LinearInterpolation(
-            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation broken=VERSION <
-                                                                                               v"1.11" &&
+            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation &&
                                                                                                t isa
                                                                                                AbstractRange
         A_s = LinearInterpolation(u_s, t; extrapolation = ExtrapolationType.Extension)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -88,7 +88,7 @@ end
         # Test allocation-free interpolation with StaticArrays
         u_s = [convert(SVector{length(y), eltype(u_)}, i) for i in u]
         @test @inferred(LinearInterpolation(
-            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation &&
+            u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation broken=true &&
                                                                                                t isa
                                                                                                AbstractRange
         A_s = LinearInterpolation(u_s, t; extrapolation = ExtrapolationType.Extension)

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -933,6 +933,7 @@ end
     push!(u, 1.0)
     @test_throws AssertionError CubicHermiteSpline(du, u, t)
 
+    deleteat!(u, lastindex(u))
     @testset "Vector of Vectors case" begin
         u2 = [[u[i], u[i] + 1] for i in eachindex(u)]
         du2 = [[du[i], du[i]] for i in eachindex(du)]
@@ -942,6 +943,7 @@ end
     @testset "Vector of Matrices case" begin
         u3 = [[u[i] u[i] + 1] for i in eachindex(u)]
         du3 = [[du[i] du[i]] for i in eachindex(du)]
+        @test length(u3) == length(du3)
         A3 = CubicHermiteSpline(du3, u3, t)
         @test u3 ≈ A3.(t)
     end
@@ -981,6 +983,7 @@ end
     @test @inferred(output_dim(A)) == 0
     @test @inferred(output_size(A)) == ()
 
+    deleteat!(u, lastindex(u))
     @testset "Vector of Vectors case" begin
         u2 = [[u[i], u[i] + 1] for i in eachindex(u)]
         du2 = [[du[i], du[i]] for i in eachindex(du)]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -89,7 +89,6 @@ end
         u_s = [convert(SVector{length(y), eltype(u_)}, i) for i in u]
         @test @inferred(LinearInterpolation(
             u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation
-         @test t isa AbstractRange
         A_s = LinearInterpolation(u_s, t; extrapolation = ExtrapolationType.Extension)
         for _x in (0, 5.5, 11)
             @test A(x) == A_s(x)


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

This hopes to address the performance issues of multi-valued interpolation discussed in #431 by using dependent variable arrays with elements of `StaticArrays.SArray` to remove allocations and improve performance. On `master` this still allocates when evaluating the interpolants, hurting performance.

For the example of `CubicSpline`, I isolated the allocations to come from the `z` array. By converting the elements of `z` to match `eltype(u)`, we are able to remove allocations when evaluating the interpolant and greatly improve the performance. Example usage and performance comparison is given below. 

All tests pass for me locally on Julia 1.11.6. If this seems like a reasonable solution, I can look into modifying the other relevant methods as well.

```julia
using StaticArrays: SVector, SArray
using DataInterpolations: CubicSpline
using BenchmarkTools: @benchmark
using  Test: @test

x = 1:1_000
a,b,c = [rand(length(x)) for i in 1:3]
y = [SVector{3, Float64}(a[i], b[i], c[i]) for i in eachindex(a,b,c)]

cubic = CubicSpline(y, x)
@benchmark $cubic($2.5)
# On master, ↑ is 133.750 ns with Memory estimate: 640 bytes, allocs estimate: 16.
# On PR: 21.717 ns, 0 allocations

y2 = [SArray{Tuple{1,2,3}, Float64, 3, 6}(rand(2,3)) for i in eachindex(a,b,c)]
cubic2 = CubicSpline(y2, x)
@benchmark $cubic2($2.5)
# On master, ↑ is 248.704 ns with Memory estimate: 1.00 KiB, allocs estimate: 16.
# On PR: 25.965 ns ns, 0 allocations

# Vector of vectors
y3 = [[a[i], b[i], c[i]] for i in eachindex(a,b,c)]
cubic3 = CubicSpline(y3, x)
@benchmark $cubic3($2.5)
# On master, ↑ is 243.811 ns with Memory estimate: 1.17 KiB, allocs estimate: 30.
# On PR: 229.563 ns with Memory estimate: 1.17 KiB, allocs estimate: 30.

# For Matrix y
y4 = [a b c]'
x4 = 1:size(y4, 2)
cubic4 = CubicSpline(y4, x4)
@benchmark $cubic4($2.5)
# On master, ↑ is 307.918 ns with Memory estimate: 1.64 KiB, allocs estimate: 42.
@test cubic(2.5) == cubic4(2.5) # Gives same result
```
