### PR TITLE
Use `hypot` for `BSplineInterpolation`, `BSplineApprox`

### DIFF
--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -824,7 +824,7 @@ function BSplineInterpolation(
     p[end] = one(eltype(t))
 
     for i in 2:n
-        s += √((t[i] - t[i - 1])^2 + (u[i] - u[i - 1])^2)
+        s += hypot(t[i] - t[i - 1], u[i] - u[i - 1])
         l[i - 1] = s
     end
     if pVecType == :Uniform
@@ -1061,7 +1061,7 @@ function BSplineApprox(
     p[end] = one(eltype(t))
 
     for i in 2:n
-        s += √((t[i] - t[i - 1])^2 + (u[i] - u[i - 1])^2)
+        s += hypot(t[i] - t[i - 1], u[i] - u[i - 1])
         l[i - 1] = s
     end
     if pVecType == :Uniform

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -799,8 +799,8 @@ end
 
         A = @inferred(BSplineInterpolation(u, t, 2, :ArcLen, :Average))
 
-        @test [A(25.0), A(80.0)] == [13.363814458968486, 10.685201117692609]
-        @test [A(190.0), A(225.0)] == [13.437481084762863, 11.367034741256463]
+        @test [A(25.0), A(80.0)] == [13.363814458968484, 10.685201117692609]
+        @test [A(190.0), A(225.0)] == [13.437481084762863, 11.367034741256461]
         @test [A(t[1]), A(t[end])] == [u[1], u[end]]
 
         @test_throws ErrorException("BSplineInterpolation needs at least d + 1, i.e. 4 points.") BSplineInterpolation(

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -799,9 +799,9 @@ end
 
         A = @inferred(BSplineInterpolation(u, t, 2, :ArcLen, :Average))
 
-        @test [A(25.0), A(80.0)] == [13.363814458968484, 10.685201117692609]
-        @test [A(190.0), A(225.0)] == [13.437481084762863, 11.367034741256461]
-        @test [A(t[1]), A(t[end])] == [u[1], u[end]]
+        @test [A(25.0), A(80.0)] ≈ [13.363814458968484, 10.685201117692609]
+        @test [A(190.0), A(225.0)] ≈ [13.437481084762863, 11.367034741256461]
+        @test [A(t[1]), A(t[end])] ≈ [u[1], u[end]]
 
         @test_throws ErrorException("BSplineInterpolation needs at least d + 1, i.e. 4 points.") BSplineInterpolation(
             u[1:3], t[1:3], 3, :Uniform, :Uniform)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Replaces the equivalent of `sqrt(x^2 + y^2)` with `hypot(x, y)` in `BSplineInterpolation` and `BSplineApprox` as `hypot` can be more accurate in some situations and is only marginally slower (~1 ns slower for Float64 arguments). Two tests broke locally due to very minor float changes -- I updated these tests and all now pass locally.

The methods that take `u::AbstractArray` have different expressions that look more like `sqrt(x^2 + sum(y.^2))` which can't be replaced with `hypot` calls so I didn't touch those , e.g.,
https://github.com/SciML/DataInterpolations.jl/blob/618ff4b787cf286c5fef64901d22fbeb12d8b272/src/interpolation_caches.jl#L905-L908
