### PR TITLE
Remove ununsed `uType`

### DIFF
--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -503,11 +503,10 @@ struct QuadraticSpline{uType, tType, IType, pType, kType, cType, scType, T} <:
 end
 
 function QuadraticSpline(
-        u::uType, t; extrapolation::ExtrapolationType.T = ExtrapolationType.None,
+        u::AbstractVector{<:Number}, t; extrapolation::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_left::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_right::ExtrapolationType.T = ExtrapolationType.None,
-        cache_parameters = false, assume_linear_t = 1e-2) where {uType <:
-                                                                 AbstractVector{<:Number}}
+        cache_parameters = false, assume_linear_t = 1e-2)
     extrapolation_left,
     extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)
@@ -529,11 +528,10 @@ function QuadraticSpline(
 end
 
 function QuadraticSpline(
-        u::uType, t; extrapolation::ExtrapolationType.T = ExtrapolationType.None,
+        u::AbstractVector, t; extrapolation::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_left::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_right::ExtrapolationType.T = ExtrapolationType.None, cache_parameters = false,
-        assume_linear_t = 1e-2) where {uType <:
-                                       AbstractVector}
+        assume_linear_t = 1e-2)
     extrapolation_left,
     extrapolation_right = munge_extrapolation(
         extrapolation, extrapolation_left, extrapolation_right)


### PR DESCRIPTION
The `uType` parameter is not used in the functions, so remove it and make the function signatures match the same pattern as the others.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

The `uType` parametric type is not used in the functions for `QuadraticSpline` so this removes them to match the call signatures of the other interpolation caches.
