### PR TITLE
Test allocations

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -38,7 +38,7 @@ function spline_coefficients!(N, d, k, u::Number)
         N[end] = one(u)
         return length(N):length(N)
     else
-        i = findfirst(x -> x > u, k) - 1
+        i = findfirst(x -> x > u, k)::Int - 1
         N[i] = one(u)
         for deg in 1:d
             N[i - deg] = (k[i + 1] - u) / (k[i + 1] - k[i - deg + 1]) * N[i - deg + 1]

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -61,7 +61,7 @@ function smoothed_constant_interpolation_parameters(
         else
             d = isone(idx) ? min(t[2] - t[1], 2d_max) / 2 :
                 min(t[end] - t[end - 1], 2d_max) / 2
-            d, zero(one(eltype(u)) / 2)
+            d, zero(first(u) / 2)
         end
     else
         min(t[idx] - t[idx - 1], t[idx + 1] - t[idx], 2d_max) / 2, (u[idx] - u[idx - 1]) / 2

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -90,7 +90,7 @@ end
         @test @inferred(LinearInterpolation(
             u_s, t; extrapolation = ExtrapolationType.Extension)) isa LinearInterpolation
         A_s = LinearInterpolation(u_s, t; extrapolation = ExtrapolationType.Extension)
-        for _x in (0, 5.5, 11)
+        for x in (0, 5.5, 11)
             @test A(x) == A_s(x)
         end
         @test A_s(0) isa SVector{length(y)}

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1020,8 +1020,18 @@ end
     @testset "Vector of Vectors case" begin
         u2 = [[u[i], u[i] + 1] for i in eachindex(u)]
         du2 = [[du[i], du[i]] for i in eachindex(du)]
-        A2 = CubicHermiteSpline(du2, u2, t)
+        A2 = CubicHermiteSpline(du2, u2, t; extrapolation = ExtrapolationType.Extension)
         @test u2 ≈ A2.(t)
+        @test A2(100.0) ≈ repeat([10.106770], 2) + [0, 1] rtol=1e-5
+        @test A2(300.0) ≈ repeat([9.901542], 2) + [0, 1] rtol=1e-5
+        # Test allocation-free interpolation with Vector{StaticArrays.SVector}
+        u2_s = [convert(SVector{length(u2[1])}, i) for i in u2]
+        du2_s = [convert(SVector{length(du2[1])}, i) for i in du2]
+        A2_s = @inferred(CubicHermiteSpline(du2_s, u2_s, t; extrapolation = ExtrapolationType.Extension))
+        @test A2_s(100.0) == A2(100.0)
+        @test A2_s(300.0) == A2(300.0)
+        @test A2_s(0.7) isa SVector{length(u2[1])}
+        @test_nowarn test_allocs(A2_s, 0.7)
     end
     @testset "Vector of Matrices case" begin
         u3 = [[u[i] u[i] + 1] for i in eachindex(u)]

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -580,6 +580,16 @@ end
         test_cached_index(A)
         @test @inferred(output_dim(A)) == 1
         @test @inferred(output_size(A)) == (2,)
+
+        # Test allocation-free interpolation with StaticArrays
+        u_s = [convert(SVector{length(first(u))}, i) for i in u]
+        A_s = @inferred(ConstantInterpolation(
+            u_s, t; extrapolation = ExtrapolationType.Extension))
+        for x in 0.5:0.5:4.5
+            @test A(x) == A_s(x)
+        end
+        @test A_s(0) isa SVector{length(first(u))}
+        @test_nowarn test_allocs(A_s, 0)
     end
 
     @testset "Vector of Matrices case" for u in [

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -777,8 +777,8 @@ end
     @test @inferred(output_size(A)) == (4,)
 
     u = [repeat(u[i], 1, 3) for i in 1:3]
-    @test_broken @inferred(CubicSpline(
-        u, t; extrapolation = ExtrapolationType.Extension)) isa CubicSpline
+    @test @inferred(CubicSpline(
+        u, t; extrapolation = ExtrapolationType.Extension)) isa CubicSpline broken=VERSION < v"1.11"
     A = CubicSpline(u, t; extrapolation = ExtrapolationType.Extension)
     for x in (-1.5, -0.5, -0.7)
         @test A(x) ≈ P₁(x) * ones(4, 3)
@@ -814,7 +814,7 @@ end
                   0.0 cos(2t)]
         t = 0.1:0.1:1.0
         u3d = f3d.(t)
-        @test_broken @inferred(CubicSpline(u3d, t)) isa CubicSpline
+        @test @inferred(CubicSpline(u3d, t)) isa CubicSpline broken=VERSION < v"1.11"
         c = CubicSpline(u3d, t)
         t_test = 0.1:0.05:1.0
         u_test = reduce(hcat, c.(t_test))


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
Following #457, this PR adds more tests for allocation-free interpolation of `Vector{SVector}` inputs. To my knowledge, all interpolators that work with vector-valued inputs now have these tests. That list is
 - CubicSpline
 - QuadraticInterpolation
 - SmoothedConstantInterpolation
 - ConstantInterpolation
 - QuadraticSpline
 - LinearInterpolation
 - CubicHermiteSpline
 - QuinticHermiteSpline

Two minor code changes are included to support this work. 

- In `spline_coefficients!` it is required to assert the return type of `findfirst(x -> x > u, k)::Int` to avoid a dynamic dispatch to `-` as `findfirst` can return an `Int` or `Nothing`. The dynamic dispatch causes the allocation check via AllocCheck.jl to fail. As bounds checks on the inputs are performed during the interpolation step, I think it is safe to assert this return type.
- The last branch in `smoothed_constant_interpolation_parameters` does not work on array-valued inputs as `one(::AbstractArray)` is not defined. I think type stability can be maintained by replacing `zero(one(eltype(u)) / 2)` with `zero(first(u) / 2)`, but this is maybe not optimal if `u` has elements of mixed type. I suppose it could be `zero(u[idx] / 2)`, other suggestions welcome.

Also some of CubicSpline `@inferred` tests that are labeled broken are now passing for me locally (Julia 1.11) so I changed those. If they fail on CI we can troubleshoot further.
