### PR TITLE
length check before return; also explicit error instead of `@assert`

### DIFF
--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -93,7 +93,8 @@ end
 # helper function for data manipulation
 function munge_data(u::AbstractVector, t::AbstractVector;
         check_sorted = t, sorted_arg_name = ("second", "t"))
-    length(t) == length(u) || error("`u`, `t` length mismatch: length(t) ≠ length(u)")
+    length(t) == length(u) ||
+        throw(ArgumentError("`u`, `t` length mismatch: length(t) ≠ length(u)"))
 
     Tu = nonmissingtype(eltype(u))
     Tt = nonmissingtype(eltype(t))
@@ -119,7 +120,8 @@ function munge_data(u::AbstractVector, t::AbstractVector;
 end
 
 function munge_data(U::AbstractMatrix, t::AbstractVector)
-    length(t) == size(U, 2) || error("`u`, `t` length mismatch: length(t) ≠ size(U, 2)")
+    length(t) == size(U, 2) ||
+        throw(ArgumentError("`u`, `t` length mismatch: length(t) ≠ size(U, 2)"))
 
     TU = nonmissingtype(eltype(U))
     Tt = nonmissingtype(eltype(t))
@@ -136,7 +138,8 @@ function munge_data(U::AbstractMatrix, t::AbstractVector)
 end
 
 function munge_data(U::AbstractArray{T, N}, t) where {T, N}
-    length(t) == size(U, N) || error("`u`, `t` length mismatch: length(t) ≠ size(U, N)")
+    length(t) == size(U, N) ||
+        throw(ArgumentError("`u`, `t` length mismatch: length(t) ≠ size(U, N)"))
 
     TU = nonmissingtype(eltype(U))
     Tt = nonmissingtype(eltype(t))

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -93,6 +93,8 @@ end
 # helper function for data manipulation
 function munge_data(u::AbstractVector, t::AbstractVector;
         check_sorted = t, sorted_arg_name = ("second", "t"))
+    length(t) == length(u) || error("`u`, `t` length mismatch: length(t) ≠ length(u)")
+
     Tu = nonmissingtype(eltype(u))
     Tt = nonmissingtype(eltype(t))
 
@@ -109,8 +111,6 @@ function munge_data(u::AbstractVector, t::AbstractVector;
         return u, t
     end
 
-    @assert length(t) == length(u)
-
     non_missing_mask = map((ui, ti) -> !ismissing(ui) && !ismissing(ti), u, t)
     u = convert(AbstractVector{Tu}, u[non_missing_mask])
     t = convert(AbstractVector{Tt}, t[non_missing_mask])
@@ -119,13 +119,14 @@ function munge_data(u::AbstractVector, t::AbstractVector;
 end
 
 function munge_data(U::AbstractMatrix, t::AbstractVector)
+    length(t) == size(U, 2) || error("`u`, `t` length mismatch: length(t) ≠ size(U, 2)")
+
     TU = nonmissingtype(eltype(U))
     Tt = nonmissingtype(eltype(t))
     if TU === eltype(U) && Tt === eltype(t)
         return U, t
     end
 
-    @assert length(t) == size(U, 2)
     non_missing_mask = map(
         (uis, ti) -> !any(ismissing, uis) && !ismissing(ti), eachcol(U), t)
     U = convert(AbstractMatrix{TU}, U[:, non_missing_mask])
@@ -135,13 +136,14 @@ function munge_data(U::AbstractMatrix, t::AbstractVector)
 end
 
 function munge_data(U::AbstractArray{T, N}, t) where {T, N}
+    length(t) == size(U, N) || error("`u`, `t` length mismatch: length(t) ≠ size(U, N)")
+
     TU = nonmissingtype(eltype(U))
     Tt = nonmissingtype(eltype(t))
     if TU === eltype(U) && Tt === eltype(t)
         return U, t
     end
 
-    @assert length(t) == size(U, N)
     non_missing_mask = map(
         (uis, ti) -> !any(ismissing, uis) && !ismissing(ti), eachslice(U; dims = N), t)
     U = convert(AbstractArray{TU, N}, copy(selectdim(U, N, non_missing_mask)))

--- a/test/derivative_tests.jl
+++ b/test/derivative_tests.jl
@@ -150,9 +150,9 @@ end
 
 @testset "Constant Interpolation" begin
     u = [0.0, 2.0, 1.0, 3.0, 2.0, 6.0, 5.5, 5.5, 2.7, 5.1, 3.0]
-    t = collect(0.0:11.0)
+    t = collect(0.0:10.0)
     A = ConstantInterpolation(u, t)
-    t2 = collect(0.0:10.0)
+    t2 = collect(0.0:9.0)
     @test all(isnan, derivative.(Ref(A), t))
     @test all(derivative.(Ref(A), t2 .+ 0.1) .== 0.0)
 end

--- a/test/integral_tests.jl
+++ b/test/integral_tests.jl
@@ -112,7 +112,7 @@ end
         args = [u, t, :Backward],
         name = "Quadratic Interpolation (Vector)")
     u = round.(rand(100), digits = 5)
-    t = 1.0collect(1:10)
+    t = 1.0collect(1:100)
     test_integral(QuadraticInterpolation; args = [u, t],
         name = "Quadratic Interpolation (Vector) with random points")
 end

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1263,7 +1263,8 @@ end
 
 @testset "user error" begin
     @test_throws ArgumentError LinearInterpolation(rand(10), rand(10))
-    @test_throws ArgumentError LinearInterpolation(0:10, rand(10))
+    @test_throws ArgumentError LinearInterpolation(1:10, rand(10))
+    @test_throws ArgumentError LinearInterpolation(1:3, 1:5)
 end
 
 @testset "Symbolic interpolation" begin


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
Currently when `Tu === eltype(u) && Tt === eltype(t)`, u, t are returned without the length/size check. This PR moves the check up so incorrect input size are detected correctly. Also changed `@assert` to `cond || error(msg)` form since `@assert`s may be ignored.