### PR TITLE
Change header for show method from time to t.

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -2,7 +2,7 @@
 
 function Base.show(io::IO, mime::MIME"text/plain", interp::AbstractInterpolation)
     print(io, get_show(interp))
-    header = ["time", get_names(interp.u)...]
+    header = ["t", get_names(interp.u)...]
     data = hcat(interp.t, get_data(interp.u))
     pretty_table(io, data; column_labels = header, vertical_crop_mode = :middle)
 end


### PR DESCRIPTION
`show(interp)` currently displays a table with headers `time` and `u`. The actual struct fields are `t` and `u`, described in the docs as "time" and "data," respectively. I find it confusing because most other tables show the property name. Here it tempts me to try `interp.time` which does not exist. 

I propose that the header be changed to `t`, for consistency with `u`.

## Checklist

- all tests still pass, no new tests needed or added
- does not harm public API
- no documentation changes needed or performed
- The new code follows contributor guidelines
  
## Additional context

An alternative solution would be to update the `u` header to say "data," so that both headers are qualitative descriptors rather than identifiers.

Technically `show` labels multidimensional data as `u1`, `u2`, etc. which also are not actual identifiers. I think this is reasonable shorthand, lacking a clearly better alternative. Also, the docs mainly emphasize one-dimensional data where `u` header is strictly correct.