### PR TITLE
Broaden Dependabot ignore rule to all GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,5 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      - dependency-name: "crate-ci/typos"
+      - dependency-name: "*"
         update-types: ["version-update:semver-patch", "version-update:semver-minor"]


### PR DESCRIPTION
## Summary
- The existing patch+minor ignore in `.github/dependabot.yml` was scoped to `crate-ci/typos` only, so every other action (TagBot, julia-actions/*, checkout, etc.) still produced a PR for every patch and minor bump (e.g. #518: TagBot 1.25.6 → 1.25.7).
- Switch `dependency-name` to `*` so patch and minor updates are ignored across all GitHub Actions; only major bumps will open a PR.

## Test plan
- [ ] Confirm Dependabot still runs on the weekly schedule and only opens PRs for major version bumps after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)