### PR TITLE
Add matrix support for AkimaInterpolation

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -215,6 +215,13 @@ function _derivative(A::AkimaInterpolation{<:AbstractVector}, t::Number, iguess)
     return @evalpoly wj A.b[idx] 2A.c[j] 3A.d[j]
 end
 
+function _derivative(A::AkimaInterpolation{<:AbstractMatrix}, t::Number, iguess)
+    idx = get_idx(A, t, iguess; idx_shift = -1, side = :first)
+    j = min(idx, size(A.c, 2))  # for smooth derivative at A.t[end]
+    wj = t - A.t[idx]
+    return @evalpoly wj A.b[:, idx] 2A.c[:, j] 3A.d[:, j]
+end
+
 function _derivative(A::ConstantInterpolation, t::Number, iguess)
     return zero(first(A.u))
 end

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -284,6 +284,15 @@ function _integral(
     return integrate_cubic_polynomial(t1, t2, A.t[idx], A.u[idx], A.b[idx], A.c[idx], A.d[idx])
 end
 
+function _integral(
+        A::AkimaInterpolation{<:AbstractMatrix{<:Number}},
+        idx::Number, t1::Number, t2::Number
+    )
+    return integrate_cubic_polynomial(
+        t1, t2, A.t[idx], A.u[:, idx], A.b[:, idx], A.c[:, idx], A.d[:, idx]
+    )
+end
+
 function _integral(A::LagrangeInterpolation, idx::Number, t1::Number, t2::Number)
     throw(IntegralNotFoundError())
 end

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -284,9 +284,11 @@ struct AkimaInterpolation{uType, tType, IType, bType, cType, dType, T} <:
 end
 
 function AkimaInterpolation(
-        u, t; extrapolation::ExtrapolationType.T = ExtrapolationType.None,
+        u::AbstractVector, t;
+        extrapolation::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_left::ExtrapolationType.T = ExtrapolationType.None,
-        extrapolation_right::ExtrapolationType.T = ExtrapolationType.None, cache_parameters = false, assume_linear_t = 1.0e-2
+        extrapolation_right::ExtrapolationType.T = ExtrapolationType.None,
+        cache_parameters = false, assume_linear_t = 1.0e-2
     )
     extrapolation_left,
         extrapolation_right = munge_extrapolation(
@@ -315,6 +317,53 @@ function AkimaInterpolation(
     ) ./ f12[ind]
     c = (3 .* m[3:(end - 2)] .- 2 .* b[1:(end - 1)] .- b[2:end]) ./ dt
     d = (b[1:(end - 1)] .+ b[2:end] .- 2 .* m[3:(end - 2)]) ./ dt .^ 2
+
+    A = AkimaInterpolation(
+        u, t, nothing, b, c, d, extrapolation_left,
+        extrapolation_right, cache_parameters, linear_lookup
+    )
+    I = cumulative_integral(A, cache_parameters)
+    return AkimaInterpolation(
+        u, t, I, b, c, d, extrapolation_left,
+        extrapolation_right, cache_parameters, linear_lookup
+    )
+end
+
+function AkimaInterpolation(
+        u::AbstractMatrix, t;
+        extrapolation::ExtrapolationType.T = ExtrapolationType.None,
+        extrapolation_left::ExtrapolationType.T = ExtrapolationType.None,
+        extrapolation_right::ExtrapolationType.T = ExtrapolationType.None,
+        cache_parameters = false, assume_linear_t = 1.0e-2
+    )
+    extrapolation_left,
+        extrapolation_right = munge_extrapolation(
+        extrapolation, extrapolation_left, extrapolation_right
+    )
+    u, t = munge_data(u, t)
+    linear_lookup = seems_linear(assume_linear_t, t)
+    n = length(t)
+    dt = diff(t)
+    dt = reshape(dt, 1, :)
+    m = Array{eltype(u)}(undef, size(u, 1), n + 3)
+    m[:, 3:(end - 2)] = diff(u; dims = 2) ./ dt
+    m[:, 2] = 2m[:, 3] - m[:, 4]
+    m[:, 1] = 2m[:, 2] - m[:, 3]
+    m[:, end - 1] = 2m[:, end - 2] - m[:, end - 3]
+    m[:, end] = 2m[:, end - 1] - m[:, end - 2]
+
+    b = (m[:, 4:end] .+ m[:, 1:(end - 3)]) ./ 2
+    dm = abs.(diff(m; dims = 2))
+    f1 = dm[:, 3:(n + 2)]
+    f2 = dm[:, 1:n]
+    f12 = f1 + f2
+    ind = findall(f12 .> 1.0e-9 .* maximum(f12; dims = 2))
+    for i in ind
+        row, col = Tuple(i)
+        b[i] = (f1[i] * m[row, col + 1] + f2[i] * m[row, col + 2]) / f12[i]
+    end
+    c = (3 .* m[:, 3:(end - 2)] .- 2 .* b[:, 1:(end - 1)] .- b[:, 2:end]) ./ dt
+    d = (b[:, 1:(end - 1)] .+ b[:, 2:end] .- 2 .* m[:, 3:(end - 2)]) ./ dt .^ 2
 
     A = AkimaInterpolation(
         u, t, nothing, b, c, d, extrapolation_left,

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -205,6 +205,12 @@ function _interpolate(A::AkimaInterpolation{<:AbstractVector}, t::Number, iguess
     return @evalpoly wj A.u[idx] A.b[idx] A.c[idx] A.d[idx]
 end
 
+function _interpolate(A::AkimaInterpolation{<:AbstractMatrix}, t::Number, iguess)
+    idx = get_idx(A, t, iguess)
+    wj = t - A.t[idx]
+    return @evalpoly wj A.u[:, idx] A.b[:, idx] A.c[:, idx] A.d[:, idx]
+end
+
 # Constant Interpolation
 function _interpolate(A::ConstantInterpolation{<:AbstractVector}, t::Number, iguess)
     if A.dir === :left

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -504,6 +504,27 @@ end
     @test @inferred(output_dim(A)) == 0
     @test @inferred(output_size(A)) == ()
 
+    # Matrix interpolation test (against Vector version)
+    u_matrix = [permutedims(u); permutedims(2u)]
+    A_matrix = @inferred(AkimaInterpolation(u_matrix, t))
+    A_row_1 = AkimaInterpolation(vec(u_matrix[1, :]), t)
+    A_row_2 = AkimaInterpolation(vec(u_matrix[2, :]), t)
+
+    for (_t, _u) in zip(t, eachcol(u_matrix))
+        @test A_matrix(_t) == _u
+    end
+    for _t in (0.5, 1.5, 5.1, 9.9)
+        @test A_matrix(_t) ≈ [A_row_1(_t), A_row_2(_t)]
+        @test DataInterpolations.derivative(A_matrix, _t) ≈ [
+            DataInterpolations.derivative(A_row_1, _t),
+            DataInterpolations.derivative(A_row_2, _t),
+        ]
+        @test DataInterpolations.derivative(A_matrix, _t, 2) ≈ [
+            DataInterpolations.derivative(A_row_1, _t, 2),
+            DataInterpolations.derivative(A_row_2, _t, 2),
+        ]
+    end
+
     # Test extrapolation
     A = @inferred(AkimaInterpolation(u, t; extrapolation = ExtrapolationType.Extension))
     @test A(-1.0) ≈ -5.0


### PR DESCRIPTION
## Summary

This PR adds `AbstractMatrix` input support for `AkimaInterpolation`.

Previously, `AkimaInterpolation(u, t)` only accepted vector-like `u`, while the documented interface supports stacked array data where the last dimension corresponds to time. With this change, matrix-valued data can be passed as:

```julia
u::AbstractMatrix  # rows are output components, columns correspond to t
t::AbstractVector
A = AkimaInterpolation(u, t)
```
For scalar evaluation times, A(t_eval) now returns a vector containing the interpolated value for each row of u.

## Changes
- Added an AkimaInterpolation(u::AbstractMatrix, t; ...) constructor.
- Added matrix-valued Akima interpolation evaluation.
- Added matrix-valued Akima derivative support for in-domain evaluation.
- Added matrix-valued Akima integral support for in-domain integration.
- Added tests comparing matrix Akima behavior against independent row-wise scalar Akima interpolations.

## Known limitation

This PR intentionally does not fix matrix-valued extrapolation.

The current generic extrapolation code in DataInterpolations uses first(A.u) and last(A.u) to obtain endpoint values. For
matrix-valued u, those return scalar array entries, not the first/last output column. This affects matrix-valued extrapolation more generally, not only Akima.

Because of that, matrix-valued extrapolation and extrapolated derivative/integral behavior should be addressed in a separate PR with a global fix.

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).

## Additional information
- Fixes #468.
- This PR builds on the earlier work in #467. I reviewed that implementation and kept the scope focused on matrix-valued `AkimaInterpolation` construction, in-domain evaluation, derivatives, and integrals.