### PR TITLE
Proposal of optimized version of AkimaInterpolation

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,11 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
+
+[sources]
+DataInterpolations = {path = ".."}
+
+[compat]
+BenchmarkTools = "1"
+StableRNGs = "1"

--- a/benchmark/makima_benchmark.jl
+++ b/benchmark/makima_benchmark.jl
@@ -1,0 +1,56 @@
+using BenchmarkTools
+using DataInterpolations
+using DataInterpolations: makima_interpolate!
+using StableRNGs
+
+seed = 1234
+rng = StableRNG(seed)
+n, n_tt, n_batch = 32, 512, 256
+
+function akima_interpolation_vector(r, u, t, tt)
+    itp = AkimaInterpolation(u, t; extrapolation=ExtrapolationType.Constant)
+    itp(r, tt)
+end
+
+function akima_interpolation_matrix(r, u, t, tt)
+    @inbounds @views for j in axes(u, 2)
+        itp = AkimaInterpolation(u[:, j], t[:, j]; extrapolation=ExtrapolationType.Constant)
+        itp(r[:, j], tt[:, j])
+    end
+end
+
+let 
+    println("="^8, "akima vs makima - vector", "="^8)
+
+    u = rand(rng, n);
+    t = sort!(rand(rng, n) * 10.0);
+    tt = sort!(rand(rng, n_tt) * 10.0);
+    r = zeros(n_tt);
+
+    println("DataInterpolation.jl")
+    @time akima_interpolation_vector(r, u, t, tt)
+    display(@benchmark akima_interpolation_vector($r, $u, $t, $tt))
+
+    println("makima vector:")
+    @time makima_interpolate!(r, u, t, tt)
+    display(@benchmark makima_interpolate!($r, $u, $t, $tt))
+end
+
+let 
+    println("="^8, "akima vs makima - matrix", "="^8)
+
+    u = rand(rng, n, n_batch);
+    t = sort!(rand(rng, n, n_batch) * 10.0, dims=1);
+    tt = sort!(rand(rng, n_tt, n_batch) * 10.0, dims=1);
+    r = zeros(n_tt, n_batch);
+
+    println("DataInterpolation.jl matrix version via loop")
+    @time akima_interpolation_matrix(r, u, t, tt)
+    display(@benchmark akima_interpolation_matrix($r, $u, $t, $tt))
+
+    println("makima matrix:")
+    @time makima_interpolate!(r, u, t, tt)
+    display(@benchmark makima_interpolate!($r, $u, $t, $tt))
+end
+
+

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -327,6 +327,232 @@ function AkimaInterpolation(
     )
 end
 
+
+
+"""
+1d kernel for initialization of the MakimaInterpolation struct arrays. 
+This version is slow, but easy to understand. It is used to verify the correctness of the optimized version `makima_init!`.
+https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.Akima1DInterpolator.html
+https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/
+"""
+function makima_init_slow!(
+    u::AbstractVector{T}, # length n
+    t::AbstractVector{T}, # length n
+    b::AbstractVector{T}, # length n
+    c::AbstractVector{T}, # length n-1
+    d::AbstractVector{T}, # length n-1
+) where {T}
+    n = length(u)
+    dt = diff(t)
+    m = Vector{T}(undef, n + 3)
+
+    m[3:(end-2)] .= diff(u) ./ dt # length n-1 and we need 2 extra points on each side
+    # pad using linear extrapolation of the first and last two slopes
+    m[2] = 2m[3] - m[4]
+    m[1] = 2m[2] - m[3]
+    m[end - 1] = 2m[end - 2] - m[end - 3]
+    m[end] = 2m[end - 1] - m[end - 2]
+
+    w1 = abs.(m[4:end] .- m[3:(end-1)]) .+ abs.(m[4:end] .+ m[3:(end-1)]) ./ 2
+    w2 = abs.(m[1:(end-3)] .- m[2:(end-2)]) .+ abs.(m[1:(end-3)] .+ m[2:(end-2)]) ./ 2
+
+    b .= (w1 .* m[2:(end-2)] .+ w2 .* m[3:(end-1)]) ./ (w1 .+ w2)
+    c .= (3 .* m[3:(end-2)] .- 2 .* b[1:(end-1)] .- b[2:end]) ./ dt
+    d .= (b[1:(end - 1)] .+ b[2:end] .- 2 .* m[3:(end - 2)]) ./ dt .^ 2
+
+    return nothing
+end
+
+"""
+1d kernel for initialization of the MakimaInterpolation struct arrays. 
+This is separated from the constructor to allow for in-place initialization of pre-allocated arrays.
+"""
+function makima_init!(
+    u::AbstractVector{T}, # length n
+    t::AbstractVector{T}, # length n
+    b::AbstractVector{T}, # length n
+    c::AbstractVector{T}, # length n-1
+    d::AbstractVector{T}, # length n-1
+) where {T}
+    n = length(u)
+    @boundscheck begin
+        length(t) == n || throw(DimensionMismatch("u and t must have the same length"))
+        length(b) == n || throw(DimensionMismatch("b must have length n"))
+        length(c) == n - 1 || throw(DimensionMismatch("c must have length n - 1"))
+        length(d) == n - 1 || throw(DimensionMismatch("d must have length n - 1"))
+        n >= 3 || throw(ArgumentError("MAkima interpolation requires at least 3 points"))
+    end
+
+    @inbounds begin
+        m3 = (u[2] - u[1]) / (t[2] - t[1])
+        m4 = (u[3] - u[2]) / (t[3] - t[2])
+        m0 = 3m3 - 2m4
+        m1 = 2m3 - m4
+        m2 = m3
+        m3 = m4
+
+        last_m0 = (u[n - 1] - u[n - 2]) / (t[n - 1] - t[n - 2])
+        last_m1 = (u[n] - u[n - 1]) / (t[n] - t[n - 1])
+        right_m0 = 2last_m1 - last_m0
+        right_m1 = 2right_m0 - last_m1
+
+        w1 = abs(m3 - m2) + abs(m3 + m2) / 2
+        w2 = abs(m0 - m1) + abs(m0 + m1) / 2
+        b[1] = (w1 * m1 + w2 * m2) / (w1 + w2)
+
+        for i in 2:(n - 2)
+            next_m = (u[i + 2] - u[i + 1]) / (t[i + 2] - t[i + 1])
+            m0 = m1
+            m1 = m2
+            m2 = m3
+            m3 = next_m
+
+            w1 = abs(m3 - m2) + abs(m3 + m2) / 2
+            w2 = abs(m0 - m1) + abs(m0 + m1) / 2
+            b[i] = (w1 * m1 + w2 * m2) / (w1 + w2)
+
+            dt = t[i] - t[i - 1]
+            c[i - 1] = (3m1 - 2b[i - 1] - b[i]) / dt
+            d[i - 1] = (b[i - 1] + b[i] - 2m1) / (dt * dt)
+        end
+
+        m0 = m1
+        m1 = m2
+        m2 = m3
+        m3 = right_m0
+        w1 = abs(m3 - m2) + abs(m3 + m2) / 2
+        w2 = abs(m0 - m1) + abs(m0 + m1) / 2
+        b[n - 1] = (w1 * m1 + w2 * m2) / (w1 + w2)
+        dt = t[n - 1] - t[n - 2]
+        c[n - 2] = (3m1 - 2b[n - 2] - b[n - 1]) / dt
+        d[n - 2] = (b[n - 2] + b[n - 1] - 2m1) / (dt * dt)
+
+        m0 = m1
+        m1 = m2
+        m2 = m3
+        m3 = right_m1
+        w1 = abs(m3 - m2) + abs(m3 + m2) / 2
+        w2 = abs(m0 - m1) + abs(m0 + m1) / 2
+        b[n] = (w1 * m1 + w2 * m2) / (w1 + w2)
+        dt = t[n] - t[n - 1]
+        c[n - 1] = (3m1 - 2b[n - 1] - b[n]) / dt
+        d[n - 1] = (b[n - 1] + b[n] - 2m1) / (dt * dt)
+    end
+
+    return nothing
+end
+
+"""
+1d kernel for evaluation of makima coefficients at points tt. 
+Assumes that tt is sorted and that constant extrapolation is used outside the range of t.
+This is separated from the call overload to allow for in-place evaluation of pre-allocated arrays.
+"""
+function makima_interpolate!(
+    r::AbstractVector{T}, # results
+    u::AbstractVector{T}, # values at the knots
+    t::AbstractVector{T}, # knot positions, sorted
+    b::AbstractVector{T},
+    c::AbstractVector{T},
+    d::AbstractVector{T},
+    tt::AbstractVector{T} # evaluation points, sorted
+) where {T}
+    @inbounds begin
+        n = length(t)
+        ntt = length(tt)
+        i = 1
+
+        # extrapolate left
+        while i <= ntt && tt[i] < t[1]
+            r[i] = u[1] # constant extrapolation
+            i += 1
+        end
+
+        # interpolate
+        for it in 1:(n - 1)
+            ti = t[it]
+            tend = t[it + 1]
+            ui = u[it]
+            bi = b[it]
+            ci = c[it]
+            di = d[it]
+
+            while i <= ntt && tt[i] <= tend
+                x = tt[i] - ti
+                r[i] = @evalpoly x ui bi ci di
+                i += 1
+            end
+        end
+
+        # extrapolate right
+        while i <= ntt
+            r[i] = u[n] # constant extrapolation
+            i += 1
+        end
+    end
+
+    return nothing
+end
+
+"""
+Interpolate a single vector of evaluation points.
+For multiple vectors, use the matrix version or create a custom call function based on matrix version.
+"""
+function makima_interpolate!(
+    r::AbstractVector{T}, # results
+    u::AbstractVector{T},
+    t::AbstractVector{T},
+    tt::AbstractVector{T} # evaluation points
+) where {T}
+    n = length(u)
+    b = Vector{T}(undef, n)
+    c = Vector{T}(undef, n-1)
+    d = Vector{T}(undef, n-1)
+
+    @inbounds begin
+        makima_init!(
+            u, t,
+            b, c, d
+        )
+        makima_interpolate!(
+            r, u, t,
+            b, c, d,
+            tt,
+        )
+    end
+
+    return nothing
+end
+
+"""
+Interpolate multiple vectors of evaluation points in a loop reusing the same pre-allocated arrays for the coefficients.
+"""
+function makima_interpolate!(
+    r::AbstractMatrix{T}, # results
+    u::AbstractMatrix{T},
+    t::AbstractMatrix{T},
+    tt::AbstractMatrix{T} # evaluation points
+) where {T}
+    n, n_batch = size(u)
+    b = Vector{T}(undef, n)
+    c = Vector{T}(undef, n-1)
+    d = Vector{T}(undef, n-1)
+
+    @inbounds @views for j in axes(u, 2)
+        makima_init!(
+            u[:, j], t[:, j],
+            b, c, d
+        )
+        makima_interpolate!(
+            r[:, j], u[:, j], t[:, j],
+            b, c, d,
+            tt[:, j],
+        )
+    end
+
+    return nothing
+end
+
+
 """
     ConstantInterpolation(u, t; dir = :left, extrapolation::ExtrapolationType.T = ExtrapolationType.None, extrapolation_left::ExtrapolationType.T = ExtrapolationType.None,
         extrapolation_right::ExtrapolationType.T = ExtrapolationType.None, cache_parameters = false)

--- a/test/akima_test.jl
+++ b/test/akima_test.jl
@@ -1,0 +1,35 @@
+using DataInterpolations
+
+# Dependent variable
+u = [14.7, 11.51, 10.41, 14.95, 12.24, 11.22]
+
+# Independent variable
+t = [0.0, 62.25, 109.66, 162.66, 205.8, 252.3]
+
+t_eval_3 = [50.0, 100.0, 150.0]
+
+# Matrix example (stacked form)
+u_matrix = [14.7 11.51 10.41 14.95 12.24 11.22;
+            7.35 5.76 5.21 7.48 6.12 5.61]
+#A_matrix = CubicSpline(u_matrix, t)
+A_matrix = AkimaInterpolation(u_matrix, t)
+
+# Pre-allocate for 3 evaluation points
+out_matrix = zeros(2, 3)
+A_matrix(out_matrix, t_eval_3)
+
+A_matrix(t_eval_3)
+
+println(out_matrix)
+
+
+M = [
+    1.0 2.0 3.0;
+    4.0 5.0 6.0;
+    7.0 8.0 9.0
+]
+
+M3 = rand(3, 3, 3)
+
+
+ind = findall(x -> x > 1/2, M3)

--- a/test/makima_test.jl
+++ b/test/makima_test.jl
@@ -1,0 +1,67 @@
+using DataInterpolations
+using DataInterpolations: makima_init!, makima_init_slow!, makima_interpolate!
+using StableRNGs
+using Test
+
+function coefficients(u::AbstractVector{T}, t::AbstractVector{T}) where {T}
+    n = length(u)
+    b = Vector{T}(undef, n)
+    c = Vector{T}(undef, n - 1)
+    d = Vector{T}(undef, n - 1)
+    makima_init!(u, t, b, c, d)
+    return b, c, d
+end
+
+function coefficients_slow(u::AbstractVector{T}, t::AbstractVector{T}) where {T}
+    n = length(u)
+    b = Vector{T}(undef, n)
+    c = Vector{T}(undef, n - 1)
+    d = Vector{T}(undef, n - 1)
+    makima_init_slow!(u, t, b, c, d)
+    return b, c, d
+end
+
+function strict_random_grid(rng, ::Type{T}, n::Int) where {T}
+    gaps = T(0.1) .+ rand(rng, T, n - 1)
+    t = Vector{T}(undef, n)
+    t[1] = zero(T)
+    @inbounds for i in 2:n
+        t[i] = t[i - 1] + gaps[i - 1]
+    end
+    return t
+end
+
+@testset "Makima module" begin
+    @testset "sin approximation" begin
+        n = 48
+        ntt = 1000
+        t = collect(range(0.0, 2pi; length=n))
+        u = sin.(t)
+        tt = collect(range(first(t), last(t); length=ntt))
+        r = similar(tt)
+
+        makima_interpolate!(r, u, t, tt)
+
+        @test maximum(abs.(r .- sin.(tt))) < 2e-3
+        @test isapprox(r[1], u[1]; atol=1e-14, rtol=1e-12)
+        @test isapprox(r[end], u[end]; atol=1e-14, rtol=1e-12)
+    end
+
+    @testset "fast init matches slow init" begin
+        rng = StableRNG(1234)
+
+        for T in (Float32, Float64), n in (3, 4, 8, 17, 64)
+            for _ in 1:20
+                t = strict_random_grid(rng, T, n)
+                u = randn(rng, T, n)
+
+                b, c, d = coefficients(u, t)
+                b_ref, c_ref, d_ref = coefficients_slow(u, t)
+
+                @test b ≈ b_ref
+                @test c ≈ c_ref
+                @test d ≈ d_ref
+            end
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,4 +40,8 @@ const GROUP = get(ENV, "GROUP", "All")
         @safetestset "Quality Assurance" include("qa.jl")
         @safetestset "Allocation Tests" include("alloc_tests.jl")
     end
+
+    if GROUP == "MakimaTest"
+        include("makima_test.jl")
+    end
 end


### PR DESCRIPTION
## Proposal
I have created highly optimized version of Akima interpolation - to be specific Makima i.e modified Akima ([source](https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/))

Proposed Makima implementation is 12-16x faster than the currently implemented Akima implementation. Additionally compile times are >10x faster.

It achieves this result by creating a 1d kernel that works on `u`, `t` vectors (or views) with 0 allocations and cache friendly memory access. Furthermore the interpolation (equivalent of `_interpolate`) is guaranteed to run in $O(n + m)$ rather than the current $O(n * log(m))$ where `n, m = length(u), length(t)`

<img width="965" height="1285" alt="image" src="https://github.com/user-attachments/assets/a1da940a-970f-4587-9d68-78484125a9b9" />

## Akima vs Makima
The difference is that instead of doing
$w1 = |m_{i+1} - m_{i}|, w2 = |m_{i-1} - m_{i-2}|$
$b = \frac{w1 * m_{i-1} + w2 * m_i}{w1 + w2}$ if $w1 + w2 > 0$
$b = \frac{m_{i-1} + m_i}{2}$ if $w1 + w2 = 0$
in Makima we do
$w1 = |m_{i+1} - m_{i}| + |m_{i+1} + m_{i}|/2, w2 = |m_{i-1} - m_{i-2}| + |m_{i-1} + m_{i-2}|/2$
$b = \frac{w1 * m_{i-1} + w2 * m_i}{w1 + w2}$
and doing so we avoid the edge case of $w1 + w2 = 0$

## Correctness tests
Run the tests using:
```julia
julia --project=. -e 'ENV["GROUP"]="MakimaTest"; using Pkg; Pkg.test()'
```

