### PR TITLE
Fix data race in BSpline and QuadraticSpline evaluation

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -256,7 +256,8 @@ function _derivative(A::BSplineInterpolation{<:AbstractVector{<:Number}}, t::Num
     n = length(A.t)
     scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
     t_ = A.p[idx] + (t - A.t[idx]) * scale
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), n) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), n)
     spline_coefficients!(sc, A.d - 1, A.k, t_)
     ducum = zero(eltype(A.u))
     if t == A.t[1]
@@ -280,7 +281,8 @@ function _derivative(
     n = length(A.t)
     scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
     t_ = A.p[idx] + (t - A.t[idx]) * scale
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), n) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), n)
     spline_coefficients!(sc, A.d - 1, A.k, t_)
     ducum = zeros(size(A.u)[1:(end - 1)]...)
     if t == A.t[1]
@@ -302,7 +304,8 @@ function _derivative(A::BSplineApprox{<:AbstractVector{<:Number}}, t::Number, ig
     idx = get_idx(A, t, iguess)
     scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
     t_ = A.p[idx] + (t - A.t[idx]) * scale
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), A.h) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), A.h)
     spline_coefficients!(sc, A.d - 1, A.k, t_)
     ducum = zero(eltype(A.u))
     if t == A.t[1]
@@ -325,7 +328,8 @@ function _derivative(
     idx = get_idx(A, t, iguess)
     scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
     t_ = A.p[idx] + (t - A.t[idx]) * scale
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), A.h) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), A.h)
     spline_coefficients!(sc, A.d - 1, A.k, t_)
     ducum = zeros(size(A.u)[1:(end - 1)]...)
     if t == A.t[1]

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -646,7 +646,7 @@ function QuadraticSpline(
     k, A = quadratic_spline_params(t, sc)
     c = A \ u
 
-    p = QuadraticSplineParameterCache(u, t, k, c, sc, cache_parameters)
+    p = QuadraticSplineParameterCache(u, t, k, c, cache_parameters)
     A = QuadraticSpline(
         u, t, nothing, p, k, c, sc, extrapolation_left,
         extrapolation_right, cache_parameters, assume_linear_t
@@ -686,7 +686,7 @@ function QuadraticSpline(
         end
     end
 
-    p = QuadraticSplineParameterCache(u, t, k, c, sc, cache_parameters)
+    p = QuadraticSplineParameterCache(u, t, k, c, cache_parameters)
     A = QuadraticSpline(
         u, t, nothing, p, k, c, sc, extrapolation_left,
         extrapolation_right, cache_parameters, assume_linear_t

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1151,7 +1151,8 @@ function _interpolate(
     idx = get_idx(A, t, iguess)
     t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
     n = length(A.t)
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), n) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), n)
     nonzero_coefficient_idxs = spline_coefficients!(sc, A.d, A.k, t)
     ucum = zero(eltype(A.u))
     for i in nonzero_coefficient_idxs
@@ -1172,7 +1173,8 @@ function _interpolate(
     idx = get_idx(A, t, iguess)
     t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
     n = length(A.t)
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), n) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), n)
     nonzero_coefficient_idxs = spline_coefficients!(sc, A.d, A.k, t)
     ucum = zeros(eltype(A.u), size(A.u)[1:(end - 1)]...)
     for i in nonzero_coefficient_idxs
@@ -1188,7 +1190,8 @@ function _interpolate(A::BSplineApprox{<:AbstractVector{<:Number}}, t::Number, i
     # change t into param [0 1]
     idx = get_idx(A, t, iguess)
     t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), A.h) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), A.h)
     nonzero_coefficient_idxs = spline_coefficients!(sc, A.d, A.k, t)
     ucum = zero(eltype(A.u))
     for i in nonzero_coefficient_idxs
@@ -1206,7 +1209,8 @@ function _interpolate(
     # change t into param [0 1]
     idx = get_idx(A, t, iguess)
     t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
-    sc = t isa ForwardDiff.Dual ? zeros(eltype(t), A.h) : A.sc
+    # Per-call scratch buffer: evaluation must be reentrant for thread safety (#532)
+    sc = zeros(eltype(t), A.h)
     nonzero_coefficient_idxs = spline_coefficients!(sc, A.d, A.k, t)
     ucum = zeros(eltype(A.u), size(A.u)[1:(end - 1)]...)
     for i in nonzero_coefficient_idxs

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -275,7 +275,7 @@ function get_parameters(A::QuadraticSpline, idx)
     return if A.cache_parameters
         A.p.α[idx], A.p.β[idx]
     else
-        quadratic_spline_parameters(A.u, A.t, A.k, A.c, A.sc, idx)
+        quadratic_spline_parameters(A.u, A.t, A.k, A.c, idx)
     end
 end
 

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -131,27 +131,40 @@ struct QuadraticSplineParameterCache{pType}
     β::pType
 end
 
-function QuadraticSplineParameterCache(u, t, k, c, sc, cache_parameters)
+function QuadraticSplineParameterCache(u, t, k, c, cache_parameters)
     return if cache_parameters
         parameters = quadratic_spline_parameters.(
-            Ref(u), Ref(t), Ref(k), Ref(c), Ref(sc), 1:(length(t) - 1)
+            Ref(u), Ref(t), Ref(k), Ref(c), 1:(length(t) - 1)
         )
         α, β = collect.(eachrow(stack(collect.(parameters))))
         QuadraticSplineParameterCache(α, β)
     else
         # Compute parameters once to infer types
-        α, β = quadratic_spline_parameters(u, t, k, c, sc, 1)
+        α, β = quadratic_spline_parameters(u, t, k, c, 1)
         QuadraticSplineParameterCache(typeof(α)[], typeof(β)[])
     end
 end
 
-function quadratic_spline_parameters(u, t, k, c, sc, idx)
+function quadratic_spline_parameters(u, t, k, c, idx)
     tᵢ₊ = (t[idx] + t[idx + 1]) / 2
-    nonzero_coefficient_idxs = spline_coefficients!(sc, 2, k, tᵢ₊)
+    # Value of the spline at the segment midpoint via the (degree 2) B-spline basis.
+    # The three nonzero basis values are evaluated into local variables rather than a
+    # shared scratch buffer so that evaluation is reentrant / thread-safe (#532).
+    # `tᵢ₊` is always interior, so only the non-boundary branch of the Cox-de Boor
+    # recursion is needed (cf. `spline_coefficients!`).
+    i = findfirst(x -> x > tᵢ₊, k)::Int - 1
+    w₁ = (k[i + 1] - tᵢ₊) / (k[i + 1] - k[i])
+    w₂ = (tᵢ₊ - k[i]) / (k[i + 1] - k[i])
+    N₁ = (k[i + 1] - tᵢ₊) / (k[i + 1] - k[i - 1]) * w₁
+    N₂ = (tᵢ₊ - k[i - 1]) / (k[i + 1] - k[i - 1]) * w₁ +
+        (k[i + 2] - tᵢ₊) / (k[i + 2] - k[i]) * w₂
+    N₃ = (tᵢ₊ - k[i]) / (k[i + 2] - k[i]) * w₂
+    # Seed the accumulator with `zero(first(u))` (as the buffer-based version did) so
+    # `uᵢ₊` keeps the element type of `u` for vector-valued data.
     uᵢ₊ = zero(first(u))
-    for j in nonzero_coefficient_idxs
-        uᵢ₊ += sc[j] * c[j]
-    end
+    uᵢ₊ += N₁ * c[i - 2]
+    uᵢ₊ += N₂ * c[i - 1]
+    uᵢ₊ += N₃ * c[i]
     α = 2 * (u[idx + 1] + u[idx]) - 4uᵢ₊
     β = 4 * (uᵢ₊ - u[idx]) - (u[idx + 1] - u[idx])
     return α, β

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ const GROUP = get(ENV, "GROUP", "All")
     if GROUP == "All" || GROUP == "Methods"
         @testset "Methods" begin
             @safetestset "Derivative Tests" include("derivative_tests.jl")
+            @safetestset "Thread Safety Tests" include("thread_safety_tests.jl")
             @safetestset "Integral Tests" include("integral_tests.jl")
             @safetestset "Integral Inverse Tests" include("integral_inverse_tests.jl")
             @safetestset "Online Tests" include("online_tests.jl")

--- a/test/thread_safety_tests.jl
+++ b/test/thread_safety_tests.jl
@@ -17,6 +17,8 @@ function thread_safety_interpolants()
             1.0 0.0 1.0 0.0 1.0 0.0]            # 2 × length(t): last axis indexes t
     return [
         ("BSplineInterpolation", BSplineInterpolation(u, t, 3, :Uniform, :Average)),
+        # degree 1 == "linear" B-spline: same `_interpolate` method, so equally affected
+        ("BSplineInterpolation (degree 1)", BSplineInterpolation(u, t, 1, :Uniform, :Average)),
         ("BSplineApprox", BSplineApprox(u, t, 3, 4, :Uniform, :Average)),
         ("BSplineInterpolation (array)", BSplineInterpolation(umat, t, 3, :Uniform, :Average)),
         ("BSplineApprox (array)", BSplineApprox(umat, t, 3, 4, :Uniform, :Average)),

--- a/test/thread_safety_tests.jl
+++ b/test/thread_safety_tests.jl
@@ -1,0 +1,66 @@
+using DataInterpolations
+using DataInterpolations: derivative
+using Test
+using Base.Threads
+
+# Regression tests for issue #532: a `BSplineInterpolation`, `BSplineApprox` or
+# (default, uncached) `QuadraticSpline` kept a scratch buffer in its `sc` field
+# and overwrote it in place on every evaluation. Because a "read" (evaluation)
+# mutated shared state, evaluating one shared interpolant from several threads
+# silently returned wrong values. Evaluation (and differentiation) must be
+# reentrant: it must not write to any state stored in the interpolant.
+
+function thread_safety_interpolants()
+    u = [0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+    t = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+    umat = [0.0 1.0 0.0 1.0 0.0 1.0
+            1.0 0.0 1.0 0.0 1.0 0.0]            # 2 × length(t): last axis indexes t
+    return [
+        ("BSplineInterpolation", BSplineInterpolation(u, t, 3, :Uniform, :Average)),
+        ("BSplineApprox", BSplineApprox(u, t, 3, 4, :Uniform, :Average)),
+        ("BSplineInterpolation (array)", BSplineInterpolation(umat, t, 3, :Uniform, :Average)),
+        ("BSplineApprox (array)", BSplineApprox(umat, t, 3, 4, :Uniform, :Average)),
+        ("QuadraticSpline", QuadraticSpline(u, t)),                       # cache_parameters = false
+        ("QuadraticSpline (cache_parameters)", QuadraticSpline(u, t; cache_parameters = true)),
+    ]
+end
+
+@testset "Thread safety / reentrancy (issue #532)" begin
+    pts = collect(range(1.0, 6.0; length = 41))   # includes the knots themselves
+
+    # Deterministic guard (catches the bug even on a single thread): repeated and
+    # interleaved evaluation must leave the interpolant's scratch buffer — and its
+    # results — unchanged.
+    @testset "evaluation does not mutate the interpolant: $name" for (name, A) in
+                                                                     thread_safety_interpolants()
+        sc_before = copy(A.sc)
+        ref = [A(x) for x in pts]
+        dref = [derivative(A, x) for x in pts]
+        for _ in 1:200, x in pts
+            A(x)
+            derivative(A, x)
+        end
+        @test A.sc == sc_before
+        @test [A(x) for x in pts] == ref
+        @test [derivative(A, x) for x in pts] == dref
+    end
+
+    # End-to-end check: many threads hammering one shared interpolant must all
+    # agree with the single-threaded reference. Only meaningful with >1 thread.
+    if Threads.nthreads() > 1
+        @testset "concurrent evaluation is race-free: $name" for (name, A) in
+                                                                 thread_safety_interpolants()
+            ref = [A(x) for x in pts]
+            wrong = Threads.Atomic{Int}(0)
+            Threads.@threads for _ in 1:50_000
+                for (j, x) in enumerate(pts)
+                    A(x) == ref[j] || Threads.atomic_add!(wrong, 1)
+                end
+            end
+            @test wrong[] == 0
+        end
+    else
+        @info "issue #532: concurrent stress test skipped; start Julia with more " *
+              "than one thread (e.g. `julia -t auto`) to exercise it."
+    end
+end


### PR DESCRIPTION
Fixes #532.

## Problem

`BSplineInterpolation`, `BSplineApprox`, and `QuadraticSpline` (with the default `cache_parameters = false`) keep a scratch buffer in their `sc` field and overwrite it in place on **every evaluation**:

```julia
sc = t isa ForwardDiff.Dual ? zeros(eltype(t), n) : A.sc
spline_coefficients!(sc, A.d, A.k, t)   # writes basis(t) into A.sc
for i in nonzero_coefficient_idxs
    ucum += sc[i] * A.c[i]              # then reads A.sc back
end
```

Because a "read" (evaluation) mutates state inside the object, evaluation is **not reentrant**. Two threads evaluating a single shared interpolant race on `A.sc`: one thread's `spline_coefficients!` overwrites the buffer between the other thread's write and read, silently producing a wrong result (no error is thrown).

The issue reported `BSplineInterpolation`, but the same root cause affects `QuadraticSpline` via `quadratic_spline_parameters` (and therefore its derivatives and integrals too). Confirmed on this branch's pre-fix state: `QuadraticSpline` gives ~12k wrong / 2M concurrent evals; `BSplineInterpolation` ~1.5–4k wrong / 2M.

## Fix

- **`BSplineInterpolation` / `BSplineApprox`** (`interpolation_methods.jl`, `derivatives.jl`): allocate the coefficient scratch per call instead of reusing `A.sc`. This is exactly the fix suggested in the issue and collapses into the pre-existing `ForwardDiff.Dual` branch.
- **`QuadraticSpline`** (`parameter_caches.jl`): evaluate the three nonzero degree-2 B-spline basis values in local variables instead of writing them into the shared `A.sc` buffer. Numerically identical to the old `spline_coefficients!` path (verified to `0.0` over 5000 random knot configs), and **allocation-free** for both scalar and `SVector`-valued data, so the `alloc_tests.jl` guarantee is preserved.
- **Regression tests** (`test/thread_safety_tests.jl`, wired into the Methods group): a deterministic "evaluation does not mutate the interpolant" check that catches the bug even on a single thread, plus a concurrent stress test that runs when more than one thread is available. Covers scalar and array-valued `BSplineInterpolation`/`BSplineApprox`, a degree-1 (linear) `BSplineInterpolation`, and `QuadraticSpline` (cached + uncached).

## Linear B-splines

For clarity, since it came up: a degree-1 `BSplineInterpolation` ("linear B-spline") **is** affected and **is** fixed — it dispatches to the same `_interpolate` method as higher degrees, so it shared the race (35 wrong / 1M before → 0 after). The separate `LinearInterpolation` type is **not** affected: it keeps no scratch buffer (no `sc` field) and recomputes from read-only fields per call, exactly like the `CubicSpline` control in the issue.

## Benchmarks

Apple silicon, Julia 1.12.5, `@belapsed`, single interior evaluation point; `n` = number of data points (BSpline scratch buffer is size `n`, BSplineApprox size `h = n÷2`).

**Evaluation `A(x)` — time / allocations:**

| type | n | before | after |
|---|---|---|---|
| `BSplineInterpolation` | 10 | 58 ns / 0 B | 48 ns / 144 B |
| | 100 | 74 ns / 0 B | 77 ns / 928 B |
| | 1000 | 263 ns / 0 B | 381 ns / 8256 B |
| `BSplineApprox` | 10 | 60 ns / 0 B | 44 ns / 96 B |
| | 100 | 71 ns / 0 B | 67 ns / 480 B |
| | 1000 | 241 ns / 0 B | 332 ns / 4160 B |
| `QuadraticSpline` (uncached, default) | 10 | 59 ns / 0 B | **19 ns / 0 B** |
| | 100 | 75 ns / 0 B | **26 ns / 0 B** |
| | 1000 | 271 ns / 0 B | **145 ns / 0 B** |
| `QuadraticSpline` (`cache_parameters=true`) | 10–1000 | ~16 ns / 0 B | ~17 ns / 0 B |

**Derivative `derivative(A, x)` (BSpline only):**

| type | n | before | after |
|---|---|---|---|
| `BSplineInterpolation` | 10 / 100 / 1000 | 31 / 80 / 725 ns, 0 B | 37 / 98 / 853 ns, 144 / 928 / 8256 B |
| `BSplineApprox` | 10 / 100 / 1000 | 29 / 55 / 456 ns, 0 B | 34 / 67 / 559 ns, 96 / 480 / 4160 B |

Takeaways:
- **`QuadraticSpline` (the default) gets ~2–3× faster and stays allocation-free.** The old path called `spline_coefficients!`, which zeroed the entire size-`n` buffer (`N .= 0`) on every call; the new functional basis computes only the 3 nonzero values.
- **`BSpline*` now allocates one scratch buffer per call** (it was allocation-free). Time impact is negligible at small `n` and grows with the buffer at large `n` (e.g. eval +45% at `n=1000`, where the 8 KB allocation dominates).
- `QuadraticSpline` with `cache_parameters=true` is unchanged.

## Tradeoff

`BSpline*` evaluation now allocates a small per-call buffer where it previously reused `A.sc`. With a runtime-variable spline degree this is the straightforward cost of reentrancy, and it matches the fix proposed in the issue; BSpline eval is not part of the allocation-free test suite. `QuadraticSpline` (fixed degree 2) stays allocation-free — and is now faster. If preferred, I can make `BSpline*` allocation-free as well via a small stack buffer (bounded max degree with a heap fallback) — happy to follow up.

Note: the `sc` struct fields are now unused at evaluation time (still built at construction). I left them in place to keep this PR focused on the correctness fix; removing them touches the struct definitions, type parameters, and constructors and can be a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
