### PR TITLE
CI: convert root test workflow to grouped-tests.yml thin caller

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -20,26 +20,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-        group:
-          - Core
-          - Methods
-          - Extensions
-          - Misc
-          - QA
-        exclude:
-          # AllocCheck doesn't work on pre-release Julia versions
-          - version: "pre"
-            group: QA
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      group: "${{ matrix.group }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,14 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[Methods]
+versions = ["lts", "1", "pre"]
+
+[Extensions]
+versions = ["lts", "1", "pre"]
+
+[Misc]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## What

Converts the root test workflow (`.github/workflows/Tests.yml`) from a hand-maintained group × version matrix into a thin caller of the reusable `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the matrix declared once in a new root `test/test_groups.toml`.

## Changes

- **`test/test_groups.toml`** (new): encodes the existing matrix.
  - `Core`, `Methods`, `Extensions`, `Misc` on `["lts", "1", "pre"]`
  - `QA` on `["lts", "1"]`
- **`.github/workflows/Tests.yml`**: the matrix+steps test job is replaced with the thin `grouped-tests.yml@v1` caller. Existing triggers (`push`/`pull_request` on `master`, `paths-ignore: docs/**`, the weekly `schedule` cron) and the `concurrency` block are preserved verbatim.

`test/runtests.jl` is **unchanged** — it already dispatches `GROUP` across `Core`/`Methods`/`Extensions`/`Misc`/`QA`, which is exactly what `grouped-tests.yml` drives (default `GROUP` env var).

No other workflows (Downgrade, Documentation, FormatCheck, SpellCheck, RunicSuggestions, DependabotAutoMerge, DocPreviewCleanup, TagBot) are touched.

## Equivalence check (static)

Running the upstream matrix script against the new TOML reproduces the original 14-job matrix exactly:

```
julia scripts/compute_affected_sublibraries.jl . --root-matrix
```

yields Core/Methods/Extensions/Misc × `{lts,1,pre}` (12) + QA × `{lts,1}` (2) = 14 jobs — identical to the previous `version × group` matrix with the `pre`+`QA` exclusion.

---

Ignore until reviewed by @ChrisRackauckas.