### PR TITLE
Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.0.0"
+version = "9.0.1"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
@@ -42,7 +42,7 @@ FiniteDifferences = "0.12.31"
 ForwardDiff = "1"
 LinearAlgebra = "1.10"
 Makie = "0.22, 0.23, 0.24"
-Mooncake = "0.4.175, 0.5"
+Mooncake = "0.5.36"
 Optim = "1.12, 2"
 PrettyTables = "2.4, 3"
 QuadGK = "2.9.1"


### PR DESCRIPTION
## Raise Mooncake compat floor to 0.5.36 (fix Downgrade resolution)

The root `Project.toml` declared `Mooncake = "0.4.175, 0.5"`. Mooncake is a
weakdep (backs `DataInterpolationsMooncakeExt`) that is *also* a test-target
dependency. `julia-actions/julia-downgrade-compat@v2` uses a **merged
resolution** for old-style `[extras]`/`[targets].test` projects and **promotes
Mooncake from weakdep to a full dependency**, then resolves it at its minimum.
With the old union floor, the downgrade job pins the ancient **Mooncake
0.4.175**, which is the "promotion-caused Downgrade `Unsatisfiable` wall".

This narrows the floor to the latest published Mooncake so the downgrade can no
longer select the ancient 0.4.x line.

### Change
- `Project.toml`: `Mooncake = "0.4.175, 0.5"` -> `Mooncake = "0.5.36"`
- version bump `9.0.0` -> `9.0.1` (compat narrowing is a patch-level change; a
  Mooncake weakdep floor is not public API)

Old floor raised: `Mooncake = "0.4.175, 0.5"` -> `"0.5.36"` (root `Project.toml`).

### Verification (`resolves_at_min` = **true**)
Ran `julia-actions/julia-downgrade-compat@v2` (the `@v2` tip = commit
`828d417`, i.e. the merged-test-deps path) on this repo on **Julia 1.12**,
`mode=deps, projects=.` — identical to the centralized
`SciML/.github/.github/workflows/downgrade.yml@v1` invocation this repo uses:

- **With the raised floor**: resolver installs **Mooncake v0.5.36** and reports
  `[ Info: Successfully resolved minimal versions for . (with extras)`. The
  downgraded environment then **instantiates and precompiles cleanly**
  (`DataInterpolations` precompiled, `INSTANTIATE_OK`, exit 0). Mooncake is
  confirmed promoted weakdep -> dependency in the merged project.
- For reference, the **original** floor resolves to the ancient **Mooncake
  0.4.175** — exactly what the raise removes.

So on the current registry snapshot the floor-raise **alone** yields a clean
downgrade min-resolution; the Resolver-capacity wall (`#52`) is **not** hit for
this repo here (`resolves_at_min = true`).

---

Please ignore until reviewed by @ChrisRackauckas.
