### PR TITLE
Migrate AD backends to a group env (test/Extensions/Project.toml)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -67,17 +67,14 @@ ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
-SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "AllocCheck", "BenchmarkTools", "SafeTestsets", "SciMLTesting", "ChainRulesCore", "Mooncake", "Optim", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful", "Zygote", "SparseConnectivityTracer"]
+test = ["Aqua", "AllocCheck", "BenchmarkTools", "SafeTestsets", "SciMLTesting", "ChainRulesCore", "Optim", "Test", "StableRNGs", "FiniteDifferences", "QuadGK", "ForwardDiff", "Symbolics", "Unitful"]

--- a/test/Extensions/Project.toml
+++ b/test/Extensions/Project.toml
@@ -1,0 +1,25 @@
+[deps]
+DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DataInterpolations = {path = "../.."}
+
+[compat]
+DataInterpolations = "9"
+ForwardDiff = "1"
+LinearAlgebra = "1.10"
+Mooncake = "0.4.175, 0.5"
+SafeTestsets = "0.1"
+SciMLTesting = "1.7"
+SparseConnectivityTracer = "1"
+Test = "1.10"
+Zygote = "0.6.77, 0.7"
+julia = "1.10"


### PR DESCRIPTION
## What

Moves the heavy optional AD/analysis backends **Mooncake**, **Zygote**, and **SparseConnectivityTracer** out of the root package's old-style `[extras]`/`[targets].test` and into a dedicated group env `test/Extensions/Project.toml` — the group whose test files (`test/Extensions/{mooncake,zygote,sparseconnectivitytracer}_tests.jl`) actually `using` them. All three are used *only* in `test/Extensions/*.jl`.

## Why

With the backends in the root test target, the root/Core **Downgrade** lane floor-resolves the Mooncake/Zygote joint dependency graph (the well-known Mooncake+Zygote joint-floor wall). Moving them into a group env means the root project no longer even attempts that joint floor-check.

Verified with the jdc-52 downgrade harness on Julia 1.12.6 (fresh depot each run):

| | weakdep extensions floor-checked | `Manifest-{Mooncake,Zygote,SparseConnectivityTracer}.toml` written? |
|---|---|---|
| **BEFORE** (master) | **7**: ChainRulesCore, Makie, Mooncake, Optim, SparseConnectivityTracer, Symbolics, Zygote | yes |
| **AFTER** (this branch) | **4**: ChainRulesCore, Makie, Optim, Symbolics | **no** |

Both runs exit 0; the base project still `Successfully resolved` after the move.

## How it stays correct

- All three moved packages remain `[weakdeps]` (they gate `DataInterpolationsMooncakeExt` / `DataInterpolationsSparseConnectivityTracerExt`; Zygote is a declared weakdep), so their root `[compat]` entries are **kept** — no dangling-compat resolver error. No pure test-only extra was moved, so no `[compat]` deletion was needed.
- The cross-backend AD tests are **unchanged** (not split per backend).
- The SciMLTesting folder harness auto-activates the group env by folder discovery, so `test/runtests.jl` (`run_tests()`) needs **no** wiring change.

## Validation (all run locally on Julia 1.12.6)

- **Downgrade** BEFORE/AFTER as above — both exit 0; AFTER drops the three from the floor-check set and writes none of their manifests.
- **Group env resolve**: `julia --project=test/Extensions -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate()'` → exit 0; resolves Mooncake 0.5.36, Zygote 0.7.11, SparseConnectivityTracer 1.2.2, ForwardDiff 1.4.1; `DataInterpolationsMooncakeExt` + `DataInterpolationsSparseConnectivityTracerExt` precompile.
- **`GROUP=Core` `Pkg.test`** (root env, without the backends): passes — extrapolation 106/106, interface 28/28, interpolation 17412 pass / 5 pre-existing broken, parameter 20/20; "Testing DataInterpolations tests passed".

---

Please ignore until reviewed by @ChrisRackauckas.