### PR TITLE
Bump version to 9.0.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.0.0"
+version = "9.0.1"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Automated patch version bump (9.0.0 -> 9.0.1) to release unreleased commits on `master` via JuliaRegistrator.