### PR TITLE
Release prep: bump to 9.0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.0.1"
+version = "9.0.2"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Version-bump-only release PR. Includes an internal bspline_nonzero_coefficients rewrite (MVector scratch -> immutable SVector rebuild); mathematically equivalent, verified by full test suite in this PR.