### PR TITLE
Bump DataInterpolations to v9.0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.0.2"
+version = "9.0.3"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Bumps `DataInterpolations` **v9.0.2 → v9.0.3** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Use strict SciMLTesting 2.4 QA (#558) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)