### PR TITLE
Adding matrix u extrapolation methods for basic interpolation schemes

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -22,9 +22,9 @@ function _extrapolate_derivative_left(A, t, order)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
-        zero(first(A.u) / one(A.t[1]))
+        zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_left == ExtrapolationType.Linear
-        (order == 1) ? _derivative(A, first(A.t), 1) : zero(first(A.u) / one(A.t[1]))
+        (order == 1) ? _derivative(A, first(A.t), 1) : zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_left == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -58,10 +58,10 @@ function _extrapolate_derivative_right(A, t, order)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
-        zero(first(A.u) / one(A.t[1]))
+        zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_right == ExtrapolationType.Linear
         (order == 1) ? _derivative(A, last(A.t), length(A.t)) :
-            zero(first(A.u) / one(A.t[1]))
+            zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_right == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -216,7 +216,7 @@ function _derivative(A::AkimaInterpolation{<:AbstractVector}, t::Number, iguess)
 end
 
 function _derivative(A::ConstantInterpolation, t::Number, iguess)
-    return zero(first(A.u))
+    return zero(_first(A.u))
 end
 
 function _derivative(A::ConstantInterpolation{<:AbstractVector}, t::Number, iguess)

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -18,8 +18,8 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     # the index less than t2
     idx2 = get_idx(A, t2, 0; idx_shift = -1, side = :first)
 
-    total = zero(eltype(A.I))
-
+    total = isa(A.u, AbstractVector) ? zero(eltype(A.I)) : zero(A.u[:, 1])
+    
     # Lower potentially incomplete interval
     if t1 < first(A.t)
         if t2 < first(A.t)
@@ -72,11 +72,11 @@ function _extrapolate_integral_left(A, t)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
-        first(A.u) * (first(A.t) - t)
+        _first(A.u) * (first(A.t) - t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = derivative(A, first(A.t))
         Δt = first(A.t) - t
-        (first(A.u) - slope * Δt / 2) * Δt
+        (_first(A.u) - slope * Δt / 2) * Δt
     elseif extrapolation_left == ExtrapolationType.Extension
         _integral(A, 1, t, first(A.t))
     elseif extrapolation_left == ExtrapolationType.Periodic
@@ -106,11 +106,11 @@ function _extrapolate_integral_right(A, t)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
-        last(A.u) * (t - last(A.t))
+        _last(A.u) * (t - last(A.t))
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = derivative(A, last(A.t))
         Δt = t - last(A.t)
-        (last(A.u) + slope * Δt / 2) * Δt
+        (_last(A.u) + slope * Δt / 2) * Δt
     elseif extrapolation_right == ExtrapolationType.Extension
         _integral(A, length(A.t) - 1, last(A.t), t)
     elseif extrapolation_right == ExtrapolationType.Periodic
@@ -160,7 +160,7 @@ function _extrapolate_integral_right(A::SmoothedConstantInterpolation, t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = derivative(A, last(A.t))
         Δt = t - last(A.t)
-        (last(A.u) + slope * Δt / 2) * Δt
+        (_last(A.u) + slope * Δt / 2) * Δt
         _extrapolate_other(A, t, A.extrapolation_right)
     elseif extrapolation_right == ExtrapolationType.Periodic
         t_, n = transformation_periodic(A, t)
@@ -194,6 +194,15 @@ function _integral(
 end
 
 function _integral(
+        A::LinearInterpolation{<:AbstractMatrix{<:Number}},
+        idx::Number, t1::Number, t2::Number
+    )
+    slope = get_parameters(A, idx)
+    u_mean = A.u[:, idx] + slope * ((t1 + t2) / 2 - A.t[idx])
+    return u_mean * (t2 - t1)
+end
+
+function _integral(
         A::ConstantInterpolation{<:AbstractVector{<:Number}}, idx::Number, t1::Number, t2::Number
     )
     Δt = t2 - t1
@@ -203,6 +212,19 @@ function _integral(
     else
         # :right means that value to the right is used for interpolation
         return A.u[idx + 1] * Δt
+    end
+end
+
+function _integral(
+        A::ConstantInterpolation{<:AbstractMatrix{<:Number}}, idx::Number, t1::Number, t2::Number
+    )
+    Δt = t2 - t1
+    if A.dir === :left
+        # :left means that value to the left is used for interpolation
+        return A.u[:, idx] * Δt
+    else
+        # :right means that value to the right is used for interpolation
+        return A.u[:, idx + 1] * Δt
     end
 end
 
@@ -248,6 +270,19 @@ function _integral(
     )
     α, β = get_parameters(A, idx)
     uᵢ = A.u[idx]
+    tᵢ = A.t[idx]
+    t1_rel = t1 - tᵢ
+    t2_rel = t2 - tᵢ
+    Δt = t2 - t1
+    return Δt * (α * (t2_rel^2 + t1_rel * t2_rel + t1_rel^2) / 3 + β * (t2_rel + t1_rel) / 2 + uᵢ)
+end
+
+function _integral(
+        A::QuadraticInterpolation{<:AbstractMatrix{<:Number}},
+        idx::Number, t1::Number, t2::Number
+    )
+    α, β = get_parameters(A, idx)
+    uᵢ = A.u[:, idx]
     tᵢ = A.t[idx]
     t1_rel = t1 - tᵢ
     t2_rel = t2 - tᵢ

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1694,7 +1694,7 @@ function _first(u::AbstractVector)
 end
 
 function _first(u::AbstractMatrix)
-    u[:,1]
+    u[:, 1]
 end
 
 function _last(u::AbstractVector)
@@ -1702,5 +1702,5 @@ function _last(u::AbstractVector)
 end
 
 function _last(u::AbstractMatrix)
-    u[:,end]
+    u[:, end]
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -14,10 +14,10 @@ function _extrapolate_left(A, t)
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
         slope = _derivative(A, first(A.t), 1)
-        first(A.u) + zero(slope * t)
+        _first(A.u) + zero(slope * t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = _derivative(A, first(A.t), 1)
-        first(A.u) + slope * (t - first(A.t))
+        _first(A.u) + slope * (t - first(A.t))
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -29,10 +29,10 @@ function _extrapolate_right(A, t)
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
         slope = _derivative(A, last(A.t), length(A.t))
-        last(A.u) + zero(slope * t)
+        _last(A.u) + zero(slope * t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = _derivative(A, last(A.t), length(A.t))
-        last(A.u) + slope * (t - last(A.t))
+        _last(A.u) + slope * (t - last(A.t))
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -133,7 +133,7 @@ function _extrapolate_left(A::ConstantInterpolation, t)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        first(A.u)
+        _first(A.u)
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -144,7 +144,7 @@ function _extrapolate_right(A::ConstantInterpolation, t)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        last(A.u)
+        _last(A.u)
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -1686,4 +1686,21 @@ function _interpolate(A::SmoothArcLengthInterpolation, t::Number, iguess)
     end
 
     return out
+end
+
+#get first and last data point from both vector and matrix u
+function _first(u::AbstractVector)
+    first(u)
+end
+
+function _first(u::AbstractMatrix)
+    u[:,1]
+end
+
+function _last(u::AbstractVector)
+    last(u)
+end
+
+function _last(u::AbstractMatrix)
+    u[:,end]
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1687,20 +1687,3 @@ function _interpolate(A::SmoothArcLengthInterpolation, t::Number, iguess)
 
     return out
 end
-
-#get first and last data point from both vector and matrix u
-function _first(u::AbstractVector)
-    first(u)
-end
-
-function _first(u::AbstractMatrix)
-    u[:, 1]
-end
-
-function _last(u::AbstractVector)
-    last(u)
-end
-
-function _last(u::AbstractMatrix)
-    u[:, end]
-end

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -538,3 +538,20 @@ function get_transition_ts(A::SmoothedConstantInterpolation)
 end
 
 get_transition_ts(A::AbstractInterpolation) = A.t
+
+#get first and last data point from both vector and matrix u
+function _first(u::AbstractVector)
+    first(u)
+end
+
+function _first(u::AbstractMatrix)
+    u[:, 1]
+end
+
+function _last(u::AbstractVector)
+    last(u)
+end
+
+function _last(u::AbstractMatrix)
+    u[:, end]
+end

--- a/test/extrapolation_tests.jl
+++ b/test/extrapolation_tests.jl
@@ -97,12 +97,58 @@ end
     @test @inferred(A([t_eval])) == [0.0u"m"]
     @test A([t_eval]) isa Vector{typeof(0.0u"m")}
 
-    # Right constant extrapolation
+    # Right linear extrapolation
     A = LinearInterpolation(u_un, t_un; extrapolation_right = ExtrapolationType.Linear)
     t_eval = 3.0u"s"
     @test @inferred(A(t_eval)) == 3.0u"m"
     @test @inferred(A([t_eval])) == [3.0u"m"]
     @test A([t_eval]) isa Vector{typeof(3.0u"m")}
+end
+
+@testset "Constant Interpolation" begin
+    u = [1.0, 2.0]
+    t = [1.0, 2.0]
+
+    #test_extrapolation(ConstantInterpolation, u, t)
+
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == 1.0
+    @test DataInterpolations.derivative(A, t_eval) == 0.0
+    @test DataInterpolations.derivative(A, t_eval, 2) == 0.0
+    @test DataInterpolations.integral(A, t_eval) == -1.0
+    t_eval = 3.0
+
+    # Right extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == 2.0
+    @test DataInterpolations.derivative(A, t_eval) == 0.0
+    @test DataInterpolations.derivative(A, t_eval, 2) == 0.0
+    @test DataInterpolations.integral(A, t_eval) == 3.0
+
+    #Matrix u tests
+    u = [1.0 2.0; 1.0 2.0]
+    t = [1.0, 2.0]
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == [1.0, 1.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [-1.0, -1.0]
+
+    # Right extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == [2.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [3.0, 3.0]
+        
 end
 
 @testset "Linear Interpolation" begin
@@ -130,6 +176,45 @@ end
         @test DataInterpolations.integral(A, t_eval) == 4.0
         t_eval = 0.0
     end
+
+    #Matrix u tests
+    u = [1.0 2.0; 2.0 5.0]
+    t = [1.0, 2.0]
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = LinearInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == [1.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [-1.0, -2.0]
+
+    # Right extrapolation
+    A = LinearInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == [2.0, 5.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [3.5, 8.5]
+    
+    for extrapolation_type in [ExtrapolationType.Linear, ExtrapolationType.Extension]
+        # Left extrapolation
+        A = LinearInterpolation(u, t; extrapolation_left = extrapolation_type)
+        t_eval = 0.0
+        @test A(t_eval) == [0.0, -1.0]
+        @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
+        @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+        @test DataInterpolations.integral(A, t_eval) == [-0.5, -0.5]
+        
+        # Right extrapolation
+        A = LinearInterpolation(u, t; extrapolation_right = extrapolation_type)
+        t_eval = 3.0
+        @test A(t_eval) == [3.0, 8.0]
+        @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
+        @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+        @test DataInterpolations.integral(A, t_eval) == [4.0, 10.0]
+    end
+        
 end
 
 @testset "Quadratic Interpolation" begin
@@ -171,4 +256,60 @@ end
     @test DataInterpolations.derivative(A, t_eval) == df(t_eval)
     @test DataInterpolations.derivative(A, t_eval, 2) == -3
     @test DataInterpolations.integral(A, t_eval) ≈ 5.25
+
+    #Matrix u tests
+    u = [1.0 3.0 2.0; 1.0 3.0 2.0]
+    t = 1:3
+
+    test_extrapolation(QuadraticInterpolation, u, t)
+
+    # Constant left extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Constant)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [1.0, 1.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) ≈ [-1.0, -1.0]
+
+    # Constant right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Constant)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [2.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t[end], t_eval) ≈ [2.0, 2.0]
+
+    # Linear left extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Linear)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [-2.5,-2.5]
+    @test DataInterpolations.derivative(A, t_eval) == [3.5, 3.5]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) ≈ [0.75, 0.75]
+
+    # Linear right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Linear)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [-0.5, -0.5]
+    @test DataInterpolations.derivative(A, t_eval) == [-2.5, -2.5]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t[end], t_eval) ≈ [0.75, 0.75]
+
+    # Extension left extrapolation
+    f = t -> (-3t^2 + 13t - 8) / 2
+    df = t -> (-6t + 13) / 2
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Extension)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [-4.0, -4.0]
+    @test DataInterpolations.derivative(A, t_eval) == df(t_eval) * ones(2)
+    @test DataInterpolations.derivative(A, t_eval, 2) == [-3, -3]
+    @test DataInterpolations.integral(A, t_eval) ≈ [1.25, 1.25]
+
+    # Extension right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Extension)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [-2.0, -2.0]
+    @test DataInterpolations.derivative(A, t_eval) == df(t_eval) * ones(2)
+    @test DataInterpolations.derivative(A, t_eval, 2) == [-3, -3]
+    @test DataInterpolations.integral(A, t_eval) ≈ [5.25, 5.25]
 end


### PR DESCRIPTION
This PR adds support for extrapolation with matrix u for the following interpolation methods that already support interpolation with matrix u:

- `ConstantInterpolation()` using `ExtrapolationType.Constant`
- `LinearInterpolation()` using `ExtrapolationType.Constant`, `ExtrapolationType.Linear`, and `ExtrapolationType.Extension`
- `QuadraticInterpolation()` using `ExtrapolationType.Constant`, `ExtrapolationType.Linear`, and `ExtrapolationType.Extension`

It also adds supporting derivative and integral methods and tests for the above.

It should fix https://github.com/SciML/DataInterpolations.jl/issues/561

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
