### PR TITLE
Enable default Documenter doctests

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ makedocs(
     modules = [DataInterpolations],
     sitename = "DataInterpolations.jl",
     clean = true,
-    doctest = false,
     linkcheck = true,
     format = Documenter.HTML(
         assets = ["assets/favicon.ico"],


### PR DESCRIPTION
## Summary
- remove the repository-level `doctest = false` override
- use Documenter default doctest behavior

## Validation
- local Julia 1.12 package test run completed without errors
- Runic and `git diff --check`
- no `jldoctest` or `@doctest` blocks currently exist, so this preserves ordinary strict defaults for future doctests.

Ignore until reviewed by @ChrisRackauckas.