### PR TITLE
Fix SparseConnectivityTracer reductions with FillArrays 1.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
@@ -25,7 +24,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [extensions]
 DataInterpolationsChainRulesCoreExt = "ChainRulesCore"
 DataInterpolationsOptimExt = "Optim"
-DataInterpolationsSparseConnectivityTracerExt = ["SparseConnectivityTracer", "FillArrays"]
+DataInterpolationsSparseConnectivityTracerExt = "SparseConnectivityTracer"
 DataInterpolationsSymbolicsExt = "Symbolics"
 DataInterpolationsMakieExt = "Makie"
 DataInterpolationsMooncakeExt = ["Mooncake", "ChainRulesCore"]
@@ -36,7 +35,6 @@ Aqua = "0.8"
 BenchmarkTools = "1"
 ChainRulesCore = "1.26.1"
 EnumX = "1.0.5"
-FillArrays = "1.16.0"
 FindFirstFunctions = "3.2"
 FiniteDifferences = "0.12.31"
 ForwardDiff = "1"

--- a/ext/DataInterpolationsSparseConnectivityTracerExt.jl
+++ b/ext/DataInterpolationsSparseConnectivityTracerExt.jl
@@ -3,7 +3,6 @@ module DataInterpolationsSparseConnectivityTracerExt
 using SparseConnectivityTracer: AbstractTracer, Dual, primal, tracer
 using SparseConnectivityTracer: GradientTracer, gradient_tracer_1_to_1
 using SparseConnectivityTracer: HessianTracer, hessian_tracer_1_to_1
-using FillArrays: Fill # from FillArrays.jl
 using DataInterpolations:
     AbstractInterpolation,
     LinearInterpolation,
@@ -53,7 +52,7 @@ function _sct_interpolate(
     )
     t = gradient_tracer_1_to_1(t, is_der_1_zero)
     N = only(output_size(interp))
-    return Fill(t, N)
+    return fill(t, N)
 end
 function _sct_interpolate(
         interp::AbstractInterpolation,
@@ -64,7 +63,7 @@ function _sct_interpolate(
     )
     t = hessian_tracer_1_to_1(t, is_der_1_zero, is_der_2_zero)
     N = only(output_size(interp))
-    return Fill(t, N)
+    return fill(t, N)
 end #===========# #===========#
 
 # Overloads #


### PR DESCRIPTION
Fixes the current-master SparseConnectivityTracer extension failure with FillArrays 1.17.

Matrix-valued interpolations returned `Fill(t, N)` for primal-free Hessian tracers. FillArrays 1.17 checks `iszero` during `sum`, but `HessianTracer` intentionally has no primal value. The extension now returns `fill(t, N)`, preserving the output values and shape while allowing reductions to trace correctly. Since `FillArrays` is no longer used, this also removes it from the weak dependency and extension trigger.

Validated locally:
- Julia 1.12: `Pkg.test()` passed, including 600/600 SparseConnectivityTracer extension tests.
- Julia 1.12 and Julia 1.10: `test/Extensions/sparseconnectivitytracer_tests.jl` passed 600/600 with resolved FillArrays 1.17.0 and SparseConnectivityTracer 1.2.2.
- Runic check and `git diff --check` passed.

Ignore until reviewed by @ChrisRackauckas.