### PR TITLE
Invert the B-spline parameterization exactly when evaluating

### DIFF
--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -4,7 +4,7 @@ module DataInterpolations
 
 abstract type AbstractInterpolation{T} end
 
-using LinearAlgebra: LinearAlgebra, Tridiagonal, dot, norm, normalize!
+using LinearAlgebra: LinearAlgebra, Tridiagonal, dot, lu, norm, normalize!
 using RecipesBase: RecipesBase, @recipe, @series
 using PrettyTables: PrettyTables, pretty_table
 using ForwardDiff: ForwardDiff

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -254,8 +254,7 @@ function _derivative(A::BSplineInterpolation{<:AbstractVector{<:Number}}, t::Num
     t > A.t[end] && return zero(A.u[end])
     idx = get_idx(A, t, iguess)
     n = length(A.t)
-    scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
-    t_ = A.p[idx] + (t - A.t[idx]) * scale
+    t_, scale = bspline_param_and_scale(A, t, idx)
     ducum = zero(eltype(A.u))
     if t == A.t[1]
         ducum = (A.c[2] - A.c[1]) / (A.k[A.d + 2])
@@ -280,8 +279,7 @@ function _derivative(
     t > A.t[end] && return zeros(size(A.u)[1:(end - 1)]...)
     idx = get_idx(A, t, iguess)
     n = length(A.t)
-    scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
-    t_ = A.p[idx] + (t - A.t[idx]) * scale
+    t_, scale = bspline_param_and_scale(A, t, idx)
     ducum = zeros(size(A.u)[1:(end - 1)]...)
     if t == A.t[1]
         ducum = (A.c[ax_u..., 2] - A.c[ax_u..., 1]) / (A.k[A.d + 2])

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -928,6 +928,11 @@ end
 It is a curve defined by the linear combination of `n` basis functions of degree `d` where `n` is the number of data points. For more information, refer [https://pages.mtu.edu/~shene/COURSES/cs3621/NOTES/spline/B-spline/bspline-curve.html](https://pages.mtu.edu/%7Eshene/COURSES/cs3621/NOTES/spline/B-spline/bspline-curve.html).
 Extrapolation is a constant polynomial of the end points on each side.
 
+The curve is parameterized by `p ∈ [0, 1]` rather than by `t`, so both `u` and `t` are
+fitted against `p` and evaluating at a time inverts the `p ↦ t` spline. When `p` is
+affine in `t` — `:Uniform` parameters on uniformly spaced `t` — that inversion is
+closed-form; otherwise it costs a few Newton steps per evaluation.
+
 ## Arguments
 
   - `u`: data points.
@@ -951,7 +956,7 @@ Extrapolation is a constant polynomial of the end points on each side.
 
 """
 struct BSplineInterpolation{
-        uType, tType, pType, kType, cType, scType, T, propsType,
+        uType, tType, pType, kType, cType, ctType, scType, T, propsType,
     } <:
     AbstractInterpolation{T}
     u::uType
@@ -960,6 +965,8 @@ struct BSplineInterpolation{
     p::pType  # params vector
     k::kType  # knot vector
     c::cType  # control points
+    ct::ctType  # control points of the p -> t map, used to invert it
+    affine_param::Bool  # whether p is affine in t, making that inversion trivial
     sc::scType  # Spline coefficients (preallocated memory)
     pVecType::Symbol
     knotVecType::Symbol
@@ -975,6 +982,8 @@ struct BSplineInterpolation{
             p,
             k,
             c,
+            ct,
+            affine_param,
             sc,
             pVecType,
             knotVecType,
@@ -985,7 +994,7 @@ struct BSplineInterpolation{
         kind = _resolve_strategy_kind(t, t_props)
         return new{
             typeof(u), typeof(t), typeof(p), typeof(k),
-            typeof(c), typeof(sc), eltype(u), typeof(t_props),
+            typeof(c), typeof(ct), typeof(sc), eltype(u), typeof(t_props),
         }(
             u,
             t,
@@ -993,6 +1002,8 @@ struct BSplineInterpolation{
             p,
             k,
             c,
+            ct,
+            affine_param,
             sc,
             pVecType,
             knotVecType,
@@ -1080,10 +1091,12 @@ function BSplineInterpolation(
     # control points
     sc = zeros(eltype(t), n, n)
     spline_coefficients!(sc, d, k, p)
-    c = vec(sc \ u[:, :])
+    F = lu(sc)
+    c = vec(F \ u[:, :])
+    ct = F \ collect(t)
     sc = zeros(eltype(t), n)
     return BSplineInterpolation(
-        u, t, d, p, k, c, sc, pVecType, knotVecType,
+        u, t, d, p, k, c, ct, bspline_affine_param(p, t), sc, pVecType, knotVecType,
         extrapolation_left, extrapolation_right, t_props
     )
 end
@@ -1165,11 +1178,13 @@ function BSplineInterpolation(
     # control points
     sc = zeros(eltype(t), n, n)
     spline_coefficients!(sc, d, k, p)
-    c = (sc \ reshape(u, prod(size(u)[1:(end - 1)]), :)')'
+    F = lu(sc)
+    c = (F \ reshape(u, prod(size(u)[1:(end - 1)]), :)')'
     c = reshape(c, size(u)...)
+    ct = F \ collect(t)
     sc = zeros(eltype(t), n)
     return BSplineInterpolation(
-        u, t, d, p, k, c, sc, pVecType, knotVecType,
+        u, t, d, p, k, c, ct, bspline_affine_param(p, t), sc, pVecType, knotVecType,
         extrapolation_left, extrapolation_right, t_props
     )
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1252,6 +1252,29 @@ function _cubicspline_eval_sorted!(
     return nothing
 end
 
+# Query time to spline parameter. When the parameters are affine in `t` the linear
+# estimate is exact; otherwise it only seeds an exact inversion of the `p -> t` spline,
+# since using it directly would cap accuracy at O(h^2) for every degree (#567).
+@inline function bspline_param(A, t, idx)
+    p0 = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
+    A.affine_param && return p0
+    t == A.t[idx] && return A.p[idx]
+    t == A.t[idx + 1] && return A.p[idx + 1]
+    return bspline_invert_param(
+        A.d, A.k, A.ct, t, p0, A.p[idx], A.p[idx + 1], length(A.ct)
+    )
+end
+
+# `(p, dp/dt)`, the second factor being the chain-rule scale for derivatives.
+@inline function bspline_param_and_scale(A, t, idx)
+    if A.affine_param
+        scale = (A.p[idx + 1] - A.p[idx]) / (A.t[idx + 1] - A.t[idx])
+        return A.p[idx] + (t - A.t[idx]) * scale, scale
+    end
+    p = bspline_param(A, t, idx)
+    return p, inv(bspline_curve_slope(A.d, A.k, A.ct, p, length(A.ct)))
+end
+
 # BSpline Curve Interpolation
 function _interpolate(
         A::BSplineInterpolation{<:AbstractVector{<:Number}},
@@ -1262,7 +1285,7 @@ function _interpolate(
     t > A.t[end] && return A.u[end]
     # change t into param [0 1]
     idx = get_idx(A, t, iguess)
-    t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
+    t = bspline_param(A, t, idx)
     n = length(A.t)
     # Stack-allocated basis window: evaluation must be reentrant for thread safety (#532)
     vals, offset, m = bspline_nonzero_coefficients(A.d, A.k, t, n)
@@ -1283,7 +1306,7 @@ function _interpolate(
     t > A.t[end] && return A.u[ax_u..., end]
     # change t into param [0 1]
     idx = get_idx(A, t, iguess)
-    t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
+    t = bspline_param(A, t, idx)
     n = length(A.t)
     # Stack-allocated basis window: evaluation must be reentrant for thread safety (#532)
     vals, offset, m = bspline_nonzero_coefficients(A.d, A.k, t, n)

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -120,6 +120,83 @@ end
     return N, i - d - 1, d + 1
 end
 
+# The B-spline caches fit `u` against a parameter `p ∈ [0, 1]`, not against `t`, so
+# evaluating at a query time needs the inverse of the map `p ↦ t`. That map is the
+# degree-`d` spline through `(p[i], t[i])`, whose control points are stored as `ct`.
+# Approximating the inverse by linear interpolation of `(t[i], p[i])` instead caps the
+# achievable accuracy at O(h²) whatever the degree (#567).
+
+# Value of the degree-`d` spline with control points `c` at parameter `p`.
+@inline function bspline_curve_value(d, k, c, p, ncp)
+    vals, offset, m = bspline_nonzero_coefficients(d, k, p, ncp)
+    out = zero(eltype(c)) * zero(p)
+    @inbounds for l in 1:m
+        out += vals[l] * c[offset + l]
+    end
+    return out
+end
+
+# Derivative of that spline with respect to `p`.
+@inline function bspline_curve_slope(d, k, c, p, ncp)
+    if p == k[1]
+        # `bspline_nonzero_coefficients` collapses to a single weight at the left
+        # clamp, which the difference loop below would index out of range.
+        return d * (c[2] - c[1]) / (k[d + 2] - k[2])
+    end
+    vals, offset, m = bspline_nonzero_coefficients(d - 1, k, p, ncp)
+    out = zero(eltype(c)) * zero(p)
+    @inbounds for l in 1:m
+        i = offset + l - 1
+        (1 <= i <= ncp - 1) || continue
+        out += vals[l] * (c[i + 1] - c[i]) / (k[i + d + 1] - k[i + 1])
+    end
+    return out * d
+end
+
+const BSPLINE_INVERT_MAXITER = 64
+
+# Solve `T(p) = t` for `p` in the bracket `[lo, hi]`, where `T` is the spline with
+# control points `ct`. `T` matches the strictly increasing `t` at the bracket ends but
+# need not be monotone in between, so the bracket is maintained and Newton falls back
+# to bisection whenever it would step outside it.
+function bspline_invert_param(d, k, ct, t, p₀, lo, hi, ncp)
+    p = min(max(p₀, lo), hi)
+    for _ in 1:BSPLINE_INVERT_MAXITER
+        r = bspline_curve_value(d, k, ct, p, ncp) - t
+        if r > zero(r)
+            hi = p
+        elseif r < zero(r)
+            lo = p
+        else
+            break
+        end
+        pnew = p - r / bspline_curve_slope(d, k, ct, p, ncp)
+        if !(isfinite(pnew) && lo < pnew < hi)
+            pnew = (lo + hi) / 2
+        end
+        pnew == p && break
+        p = pnew
+    end
+    # One unguarded Newton step on top of the converged value. Its derivative is
+    # `1/T′(p)` up to the residual, which is at roundoff by now, so differentiating
+    # through this function recovers the implicit-function derivative rather than the
+    # derivative of the iteration itself.
+    return p - (bspline_curve_value(d, k, ct, p, ncp) - t) /
+        bspline_curve_slope(d, k, ct, p, ncp)
+end
+
+# Is `p` affine in `t`? Then the linear estimate of the inverse map is already exact
+# and evaluation can skip the inversion. Holds for `:Uniform` parameters on uniformly
+# spaced `t`, which is the common case.
+function bspline_affine_param(p, t)
+    Δp = p[end] - p[1]
+    Δt = t[end] - t[1]
+    dev = maximum(
+        abs(p[i] - (p[1] + (t[i] - t[1]) / Δt * Δp)) for i in eachindex(p)
+    )
+    return dev <= 8 * eps(float(one(dev))) * abs(Δp)
+end
+
 function quadratic_spline_params(t::AbstractVector, sc::AbstractVector)
     # Duplicate time points make the collocation system singular
     if any(i -> t[i] == t[i + 1], 1:(length(t) - 1))

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1327,8 +1327,8 @@ end
         test_interpolation_type(BSplineInterpolation)
         A = @inferred(BSplineInterpolation(u, t, 2, :Uniform, :Uniform))
 
-        @test [A(25.0), A(80.0)] == [13.454197730061425, 10.305633616059845]
-        @test [A(190.0), A(225.0)] == [14.07428439395079, 11.057784141519251]
+        @test [A(25.0), A(80.0)] == [13.595900807689079, 10.28208957935061]
+        @test [A(190.0), A(225.0)] == [14.193576669619798, 11.018696916649047]
         @test [A(t[1]), A(t[end])] == [u[1], u[end]]
         test_cached_index(A)
         @test @inferred(output_dim(A)) == 0
@@ -1348,8 +1348,8 @@ end
 
         A = @inferred(BSplineInterpolation(u, t, 2, :ArcLen, :Average))
 
-        @test [A(25.0), A(80.0)] ≈ [13.363814458968484, 10.685201117692609]
-        @test [A(190.0), A(225.0)] ≈ [13.437481084762863, 11.367034741256461]
+        @test [A(25.0), A(80.0)] ≈ [13.362987841699956, 10.685461155425084]
+        @test [A(190.0), A(225.0)] ≈ [13.43660111457438, 11.366765953659648]
         @test [A(t[1]), A(t[end])] ≈ [u[1], u[end]]
 
         @test_throws ErrorException("BSplineInterpolation needs at least d + 1, i.e. 4 points.") BSplineInterpolation(
@@ -1412,6 +1412,53 @@ end
             @test @inferred(output_dim(A)) == 2
             @test @inferred(output_size(A)) == (2, 2)
         end
+    end
+
+    # The spline is fitted against a parameter `p`, so evaluating at a time requires
+    # inverting `p -> t`. Doing that by linear interpolation of `(t[i], p[i])` limits
+    # the interpolant to 2nd order whatever the degree, whenever `p` is not affine in
+    # `t` — i.e. for `:ArcLen` parameters, or `:Uniform` ones on non-uniform `t` (#567).
+    @testset "Parameterization inversion accuracy" begin
+        f(x) = sin(x)
+        xq = range(0, 2π, length = 2001)
+        ytrue = f.(xq)
+        maxerr(A) = maximum(abs.([A(x) for x in xq] .- ytrue))
+
+        uniform_t(n) = collect(range(0, 2π, length = n))
+        # Smoothly graded, so `:Uniform` parameters are not affine in `t`.
+        graded_t(n) = π .* (1 .- cos.(range(0, π, length = n)))
+
+        @testset "$pVecType/$knotVecType, $tgen" for (pVecType, knotVecType, tgen) in (
+                (:ArcLen, :Average, uniform_t), (:Uniform, :Average, graded_t),
+            )
+            # 2nd order would give ~1.2e-4 at n = 100 for both degrees.
+            for (d, tol) in ((3, 1.0e-5), (5, 1.0e-7))
+                t = tgen(100)
+                A = BSplineInterpolation(f.(t), t, d, pVecType, knotVecType)
+                @test !A.affine_param
+                @test maxerr(A) < tol
+            end
+
+            # Convergence order grows with the degree instead of sticking at 2.
+            for (d, min_order) in ((3, 3.5), (5, 5.0))
+                t1, t2 = tgen(100), tgen(200)
+                e1 = maxerr(BSplineInterpolation(f.(t1), t1, d, pVecType, knotVecType))
+                e2 = maxerr(BSplineInterpolation(f.(t2), t2, d, pVecType, knotVecType))
+                @test log2(e1 / e2) > min_order
+            end
+
+            # Inverting the map must not disturb interpolation at the data points.
+            t = tgen(60)
+            A = BSplineInterpolation(f.(t), t, 3, pVecType, knotVecType)
+            @test maximum(abs(A(tᵢ) - f(tᵢ)) for tᵢ in t) < 1.0e-13
+        end
+
+        # `:Uniform` parameters on uniform `t` are affine, so the closed-form map is
+        # exact and the inversion is skipped.
+        t = uniform_t(100)
+        A = BSplineInterpolation(f.(t), t, 3, :Uniform, :Average)
+        @test A.affine_param
+        @test maxerr(A) < 1.0e-5
     end
 
     @testset "BSplineApprox" begin


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Fixes the second half of https://github.com/SciML/DataInterpolations.jl/issues/567. The first half (`:Uniform` knot conditioning) is a separate, stacked PR.

## The problem

`BSplineInterpolation` fits `u` against a curve parameter `p ∈ [0, 1]`, not against `t`. Evaluating `A(t)` therefore has to invert the map `p ↦ t`. `interpolation_methods.jl` did that by linear interpolation of the `(t[i], p[i])` pairs:

```julia
t = A.p[idx] + (t - A.t[idx]) / (A.t[idx + 1] - A.t[idx]) * (A.p[idx + 1] - A.p[idx])
```

That inversion is only 2nd order accurate, so it caps the entire interpolant at O(h²) *regardless of the requested degree*, whenever `p` is not affine in `t`. Two configurations are affected:

- `pVecType = :ArcLen` — always, since chord length is a nonlinear function of `t`.
- `pVecType = :Uniform` — whenever `t` is not uniformly spaced.

The reporter's diagnostic is what makes it unambiguous: for `:ArcLen`/`:Average` the errors for degree 3 and degree 5 agreed to three significant figures at every `n`, i.e. the degree was not reaching the result at all.

The spline itself was never wrong. Error measured *at the data points* is 1e-16 at every `n`; all the error is between them, and it converges at exactly order 2:

```
:ArcLen/:Average, degree 5, f = sin

     n       at nodes   at midpoints  ratio
    20      1.110e-16      3.295e-03
   160      2.220e-16      4.648e-05  4.051
   640      3.331e-16      2.878e-06  4.012
```

## The fix

Fit `t` against `p` with the same basis and knots, and invert that spline properly.

- The `t`-coordinate control points `ct` come from the collocation matrix that is already factorized for `c`, so construction costs one extra triangular solve, not another factorization.
- Evaluation solves `T(p) = t` with Newton, seeded by the old linear estimate and bracketed by `[p[idx], p[idx+1]]`. `T` matches the strictly increasing `t` at the bracket ends but need not be monotone in between, so the bracket is maintained and Newton falls back to bisection on any step that would leave it.

Degree `d` now converges at order `d + 1`. Max error of `f(x) = exp(sin 3x)` over `[0, 2π]`, `:ArcLen`/`:Average`:

|   n |  d=3 before |  d=3 after |  d=5 before |  d=5 after |
|----:|------------:|-----------:|------------:|-----------:|
| 160 |    4.24e-03 |   2.14e-03 |    8.50e-03 |   1.34e-02 |
| 320 |    8.32e-04 |   6.92e-05 |    8.87e-04 |   1.25e-04 |
| 640 |    2.07e-04 |   2.09e-06 |    2.07e-04 |   2.50e-07 |

### Differentiability

The final Newton step is taken unguarded, on purpose. Writing the Newton map as `N(p, t) = p - r(p,t)/T′(p)`, we have `∂N/∂p = r·T″/T′²`, which vanishes as the residual does, leaving `∂N/∂t = 1/T′(p)`. So once the value has converged, one more step returns the implicit-function derivative rather than the derivative of the iteration — no unrolling-error decay, and no need to strip `Dual`s (which would not have worked for `Unitful`/`Symbolics` anyway).

Verified: `derivative(A, x)` agrees with `ForwardDiff.derivative(A, x)` to 1.7e-14 on the inverting path.

### Cost

When `p` is affine in `t` — `:Uniform` parameters on uniform `t`, the common case — the closed form is already exact, so it is detected at construction (`affine_param`) and the inversion is skipped entirely.

| path | ns/eval | allocs |
|---|---:|---:|
| affine (unchanged) | 147 | 0 |
| inverting | 611 | 0 |

## ⚠️ Behaviour change — needs a version-bump decision

**`A(t)` returns different values than before for any non-affine parameterization.** This is not limited to `:ArcLen`; it includes `:Uniform` parameters on non-uniformly spaced `t`, which is common. Values *at* the data points are unchanged (still machine-precision exact).

Four hardcoded regression values in `test/interpolation_tests.jl` changed as a result. Because those are lock-in values on arbitrary data with no analytic ground truth, I did not simply paste the new output: I checked each against an **independent implementation** — a from-scratch Cox–de Boor basis, a `BigFloat` linear solve, and plain bisection (no Newton) — which reproduces the new values to 1–2 ulp:

```
--- Uniform / Uniform, degree 2 ---
  t=  25.0  package=13.595900807689079  independent=13.595900807689077  |diff|=1.78e-15
  t=  80.0  package=10.282089579350609  independent=10.282089579350608  |diff|=1.78e-15
  t= 190.0  package=14.193576669619798  independent=14.193576669619800  |diff|=1.78e-15
  t= 225.0  package=11.018696916649047  independent=11.018696916649047  |diff|=0.00e+00
--- ArcLen / Average, degree 2 ---
  t=  25.0  package=13.362987841699956  independent=13.362987841699956  |diff|=0.00e+00
  t=  80.0  package=10.685461155425084  independent=10.685461155425083  |diff|=1.78e-15
  t= 190.0  package=13.436601114574380  independent=13.436601114574382  |diff|=1.78e-15
  t= 225.0  package=11.366765953659648  independent=11.366765953659646  |diff|=1.78e-15
```

The `BSplineInterpolation` struct also gains two fields (`ct`, `affine_param`), so the undocumented positional inner constructor changed arity.

Please decide whether this ships as v9.1 or v10.

## Tests

New `@testset "Parameterization inversion accuracy"` covering both affected configurations:

- absolute error thresholds at `n = 100` that the old 2nd-order code could not meet (it sat at ~1.2e-4 for both degrees);
- observed convergence order `> 3.5` for degree 3 and `> 5.0` for degree 5, which is the property that actually regressed;
- interpolation still exact at the data points;
- `affine_param` is exercised in both states.

## Not covered

`BSplineApprox` evaluates through the same linear estimate and has the same cap. Left out to keep this reviewable; happy to follow up. Separately, while testing I noticed `BSplineApprox` with `:Average` knots does not appear to converge at all as the control point count grows (~6e-2 flat for `h = n/2`, `n = 100…400`, degree 3) — that looks like a third, unrelated bug and I have not investigated it.

## Test status

`Core`, `Methods`, `Misc` all pass. `Extensions` and `QA` each have one **pre-existing failure that reproduces identically on an unmodified `master` checkout** — I verified both against a clean worktree rather than assuming:

- `Extensions`: 8 SparseConnectivityTracer "Global Hessian sparsity" errors (`iszero` on a `HessianTracer` inside `FillArrays._foldl_length_op`). Master baseline is `592 passed, 0 failed, 8 errored`; this branch is byte-identical at `592 passed, 0 failed, 8 errored`. Version-sensitive — it passes under some resolved SCT/FillArrays combinations.
- `QA`: `all_qualified_accesses_are_public` fails because `require_one_based_indexing` is not public in `Base` but is imported at `src/interpolation_utils.jl:308`. Same on master.

Neither is touched by this PR. Happy to open separate issues for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nh5RgcPFZbKDNh1y61ZEAe
