### PR TITLE
Make the documented non-exported API public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.0.3"
+version = "9.1.0"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -16,6 +16,14 @@ PCHIPInterpolation
 QuinticHermiteSpline
 ```
 
+# Interface
+
+```@docs
+DataInterpolations.AbstractInterpolation
+DataInterpolations.derivative
+DataInterpolations.integral
+```
+
 # Utility Functions
 
 ```@docs

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -2,6 +2,30 @@ module DataInterpolations
 
 ### Interface Functionality
 
+"""
+    AbstractInterpolation{T}
+
+Supertype of all interpolation objects in DataInterpolations.jl, where `T` is the element
+type of the interpolated values.
+
+Every subtype is callable as `A(t)` to evaluate the interpolation at `t`, and supports
+[`DataInterpolations.derivative`](@ref) and [`DataInterpolations.integral`](@ref). Use it
+to dispatch on interpolations of any method.
+
+## Examples
+
+```jldoctest
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 2.0], [0.0, 1.0])
+
+A isa DataInterpolations.AbstractInterpolation
+
+# output
+
+true
+```
+"""
 abstract type AbstractInterpolation{T} end
 
 using LinearAlgebra: LinearAlgebra, Tridiagonal, dot, norm, normalize!
@@ -155,6 +179,15 @@ export LinearInterpolation, QuadraticInterpolation, LagrangeInterpolation,
     SmoothArcLengthInterpolation, LinearInterpolationIntInv,
     ConstantInterpolationIntInv, ExtrapolationType
 export output_dim, output_size
+
+# These names are part of the documented API but are deliberately not exported, since the
+# bare names would clash in user code. `public` is only parseable on Julia 1.11+, hence the
+# string.
+@static if VERSION >= v"1.11"
+    include_string(
+        @__MODULE__, "public AbstractInterpolation, derivative, integral, invert_integral"
+    )
+end
 
 # CurveFit
 struct CurvefitCache{

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -1,3 +1,38 @@
+"""
+    derivative(A::AbstractInterpolation, t::Number, order = 1)
+
+Evaluate the `order`-th derivative of the interpolation `A` at `t`.
+
+First order derivatives are computed analytically; second order derivatives are computed
+from the analytical first order derivative with ForwardDiff.jl. The derivative is taken as
+a left derivative, so at a data point where the derivative jumps the value from the
+interval to the left of the point is returned.
+
+Outside of the range of `A.t` the derivative of the extrapolation is returned, as
+determined by the `extrapolation_left` and `extrapolation_right` settings of `A`.
+
+## Arguments
+
+  - `A`: the interpolation object.
+  - `t`: the point at which to evaluate the derivative.
+  - `order`: the order of the derivative, either `1` or `2`. Defaults to `1`.
+
+## Examples
+
+```jldoctest
+using DataInterpolations
+
+u = [1.0, 4.0, 9.0]
+t = [1.0, 2.0, 3.0]
+A = QuadraticInterpolation(u, t)
+
+DataInterpolations.derivative(A, 2.5)
+
+# output
+
+5.0
+```
+"""
 function derivative(A, t, order = 1)
     (order ∉ (1, 2)) && throw(DerivativeNotFoundError())
     if t < first(A.t)

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -1,3 +1,42 @@
+"""
+    integral(A::AbstractInterpolation, t::Number)
+    integral(A::AbstractInterpolation, t1::Number, t2::Number)
+
+Evaluate the integral of the interpolation `A` over `[first(A.t), t]`, or over `[t1, t2]`
+when both bounds are given. The integral is computed analytically per interval, so it is
+exact for the interpolation. `integral(A, t2, t1) == -integral(A, t1, t2)`.
+
+Parts of the integration interval outside the range of `A.t` are integrated over the
+extrapolation, as determined by the `extrapolation_left` and `extrapolation_right`
+settings of `A`.
+
+Interpolation types with no analytical antiderivative — `LagrangeInterpolation`,
+`BSplineInterpolation`, `BSplineApprox` and `Curvefit` — throw an
+`IntegralNotFoundError`; use a numerical integrator such as
+[Integrals.jl](https://docs.sciml.ai/Integrals/stable/) for those.
+
+## Arguments
+
+  - `A`: the interpolation object.
+  - `t`: the upper bound, with `first(A.t)` used as the lower bound.
+  - `t1`, `t2`: the lower and upper bounds.
+
+## Examples
+
+```jldoctest
+using DataInterpolations
+
+u = [1.0, 2.0, 3.0]
+t = [1.0, 2.0, 3.0]
+A = LinearInterpolation(u, t)
+
+DataInterpolations.integral(A, 1.0, 3.0)
+
+# output
+
+4.0
+```
+"""
 function integral(A::AbstractInterpolation, t::Number)
     return integral(A, first(A.t), t)
 end

--- a/test/Misc/public_api.jl
+++ b/test/Misc/public_api.jl
@@ -1,0 +1,14 @@
+using DataInterpolations, Test
+
+# These names are documented for downstream use but not exported, so the `public`
+# declaration is the only thing making them reachable as public API. Docstring coverage for
+# them is checked by Aqua in the QA group.
+@testset "Public API" begin
+    @testset "$name" for name in
+        (:AbstractInterpolation, :derivative, :integral, :invert_integral)
+        @test isdefined(DataInterpolations, name)
+        if VERSION >= v"1.11"
+            @test Base.ispublic(DataInterpolations, name)
+        end
+    end
+end


### PR DESCRIPTION
## Why

`DataInterpolations.derivative`, `DataInterpolations.integral`, `DataInterpolations.invert_integral` and `DataInterpolations.AbstractInterpolation` are all documented for downstream use, but none of them are exported or declared `public`. So `Base.ispublic` reports them as internals, and any downstream package that calls them trips ExplicitImports' `all_qualified_accesses_are_public`:

```
Module `DataCollocationsDataInterpolationsExt` has explicit imports of names from modules
in which they are not public:
- `derivative` is not public in `DataInterpolations` but it was imported from
  `DataInterpolations` at ext/DataCollocationsDataInterpolationsExt.jl:15:41
```

Confirmed on unmodified `master`:

```
$ julia --project=. -e 'using DataInterpolations;
    for n in (:AbstractInterpolation, :derivative, :integral, :invert_integral)
        println(n, " ispublic=", Base.ispublic(DataInterpolations, n))
    end'
AbstractInterpolation ispublic=false
derivative ispublic=false
integral ispublic=false
invert_integral ispublic=false
```

There is currently no public spelling for any of them, so downstream packages have to carry an ignore entry (see https://github.com/SciML/DataCollocations.jl/pull/42). This PR removes the need for that.

## What changed

* **`public` declaration** for `AbstractInterpolation`, `derivative`, `integral` and `invert_integral`. The `public` keyword is only parseable on Julia 1.11+ and this package supports 1.10, so it goes through `include_string` behind a `@static if VERSION >= v"1.11"` guard. `include_string` is used rather than `Meta.parse` because `Base.Meta.parse` is itself not public, and the package's own QA run flags it.
* **Docstrings** for `derivative`, `integral` and `AbstractInterpolation`, each with a `jldoctest` example. `invert_integral` already had one. Per the "public and documented move together" rule, `docs/src/manual.md` gains an `Interface` section with `@docs` entries for the three new docstrings; `invert_integral` already had a `@docs` entry in `inverting_integrals.md`.
* **`test/Misc/public_api.jl`**: asserts each of the four names is defined and (on 1.11+) `Base.ispublic`. Docstring coverage for them is already enforced by Aqua's undocumented-names check in the QA group.
* **Version bump** `9.0.3` → `9.1.0` (new public API is a minor bump).

## Scope

Only names the docs actually tell users to call. `output_dim`/`output_size` are already exported and documented; the error types (`ExtrapolationError`, `IntegralNotFoundError`, …) are not currently documented anywhere, so they are left alone rather than being made public in the same breath.

## Local verification

Public declaration and doctest values, Julia 1.11:

```
$ julia +1.11 --project=. -e '...'
AbstractInterpolation ispublic=true
derivative ispublic=true
integral ispublic=true
invert_integral ispublic=true
output_dim ispublic=true
output_size ispublic=true
deriv = 5.0
integral = 4.0
isa = true
```

Julia 1.10 still loads (the `@static` guard is the whole point):

```
$ julia +1.10 --project=. -e 'using DataInterpolations; println("1.10 load OK: ", DataInterpolations.derivative(LinearInterpolation([1.0,2.0],[0.0,1.0]), 0.5))'
1.10 load OK: 1.0
```

Doctests:

```
$ julia +1.11 -e 'using Documenter, DataInterpolations; doctest(DataInterpolations)'
Test Summary:                | Pass  Total   Time
Doctests: DataInterpolations |    1      1  20.9s
```

(Verified the new doctests are actually being executed, not silently skipped: deliberately changing the expected `5.0` to `5.5` produces `doctest failure in src/derivatives.jl:22-34`.)

QA group, Julia 1.12:

```
$ GROUP=QA julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:     | Pass  Total     Time
QA/alloc_tests.jl |   16     16  1m54.5s
Test Summary: | Pass  Total     Time
QA/qa.jl      |   20     20  1m35.4s
     Testing DataInterpolations tests passed
```

Full default suite, Julia 1.12:

```
$ julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Test Summary:                | Pass  Total      Time
Extensions/mooncake_tests.jl |  604    604  11m39.3s
Test Summary:                                | Pass  Total     Time
Extensions/sparseconnectivitytracer_tests.jl |  600    600  2m17.3s
Test Summary:              |  Pass  Total     Time
Extensions/zygote_tests.jl | 11974  11974  6m03.0s
Test Summary:               |  Pass  Total     Time
Methods/derivative_tests.jl | 34479  34479  3m59.7s
Test Summary:                     | Pass  Total   Time
Methods/integral_inverse_tests.jl |  317    317  36.9s
Test Summary:             | Pass  Total   Time
Methods/integral_tests.jl | 6591   6591  33.1s
Test Summary:           | Pass  Total  Time
Methods/online_tests.jl |   30     30  1.7s
Test Summary:                  | Pass  Total   Time
Methods/thread_safety_tests.jl |   21     21  43.5s
Test Summary: | Pass  Total  Time
Misc/show.jl  |   10     10  6.7s
     Testing DataInterpolations tests passed
```

New test on both supported bounds:

```
$ GROUP=Misc julia +1.12 --project=. -e 'using Pkg; Pkg.test()'
Misc/public_api.jl |    8      8  1.4s
$ GROUP=Misc julia +1.10 --project=. -e 'using Pkg; Pkg.test()'
Misc/public_api.jl |    4      4  1.2s
```

Runic is clean on `src/`, `ext/`, `test/`.

## Note on a pre-existing QA quirk

Running the QA group on Julia **1.11** fails `all_qualified_accesses_are_public` on `Base.require_one_based_indexing` (`src/interpolation_utils.jl:308`). This reproduces on unmodified `master` and is not caused by this PR: `require_one_based_indexing` was made public in Julia 1.12 (`Base.ispublic(Base, :require_one_based_indexing)` is `false` on 1.11, `true` on 1.12), and `test/test_groups.toml` only runs QA on `lts` and `1`, so 1.11 is not a tested configuration. No action taken.

## Follow-up

Once this is released, https://github.com/SciML/DataCollocations.jl/pull/42 can drop its `all_qualified_accesses_are_public` ignore entry for `:derivative`.

---

This PR is a draft and should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P4PuARYzVMgfBCudt4wrA5