### PR TITLE
Matrix u extrapolation without the extra allocations (continues #563)

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -57,9 +57,9 @@ function _extrapolate_derivative_left(A, t, order)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
-        zero(first(A.u) / one(A.t[1]))
+        zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_left == ExtrapolationType.Linear
-        (order == 1) ? _derivative(A, first(A.t), 1) : zero(first(A.u) / one(A.t[1]))
+        (order == 1) ? _derivative(A, first(A.t), 1) : zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_left == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -93,10 +93,10 @@ function _extrapolate_derivative_right(A, t, order)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
-        zero(first(A.u) / one(A.t[1]))
+        zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_right == ExtrapolationType.Linear
         (order == 1) ? _derivative(A, last(A.t), length(A.t)) :
-            zero(first(A.u) / one(A.t[1]))
+            zero(_first(A.u) / one(A.t[1]))
     elseif extrapolation_right == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -251,7 +251,7 @@ function _derivative(A::AkimaInterpolation{<:AbstractVector}, t::Number, iguess)
 end
 
 function _derivative(A::ConstantInterpolation, t::Number, iguess)
-    return zero(first(A.u))
+    return zero(_first(A.u))
 end
 
 function _derivative(A::ConstantInterpolation{<:AbstractVector}, t::Number, iguess)

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -52,14 +52,21 @@ function derivative(A, t, order = 1)
     end
 end
 
+# Zero of the derivative's value type, shaped like one data point.
+function _zero_derivative(A)
+    u₁ = _first(A.u)
+    t₁ = one(A.t[1])
+    return @. zero(u₁ / t₁)
+end
+
 function _extrapolate_derivative_left(A, t, order)
     (; extrapolation_left) = A
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
-        zero(_first(A.u) / one(A.t[1]))
+        _zero_derivative(A)
     elseif extrapolation_left == ExtrapolationType.Linear
-        (order == 1) ? _derivative(A, first(A.t), 1) : zero(_first(A.u) / one(A.t[1]))
+        (order == 1) ? _derivative(A, first(A.t), 1) : _zero_derivative(A)
     elseif extrapolation_left == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -93,10 +100,9 @@ function _extrapolate_derivative_right(A, t, order)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
-        zero(_first(A.u) / one(A.t[1]))
+        _zero_derivative(A)
     elseif extrapolation_right == ExtrapolationType.Linear
-        (order == 1) ? _derivative(A, last(A.t), length(A.t)) :
-            zero(_first(A.u) / one(A.t[1]))
+        (order == 1) ? _derivative(A, last(A.t), length(A.t)) : _zero_derivative(A)
     elseif extrapolation_right == ExtrapolationType.Extension
         (order == 1) ? _derivative(A, t, length(A.t)) :
             ForwardDiff.derivative(
@@ -167,7 +173,7 @@ function _derivative(A::QuadraticInterpolation, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt = t - A.t[idx]
     α, β = get_parameters(A, idx)
-    return 2α * Δt + β
+    return @. 2α * Δt + β
 end
 
 function _derivative(A::LagrangeInterpolation{<:AbstractVector}, t::Number)
@@ -259,7 +265,8 @@ function _derivative(A::ConstantInterpolation{<:AbstractVector}, t::Number, igue
 end
 
 function _derivative(A::ConstantInterpolation{<:AbstractMatrix}, t::Number, iguess)
-    return isempty(searchsorted(A.t, t)) ? zero(A.u[:, 1]) : typed_nan(A.u) .* A.u[:, 1]
+    u₁ = _first(A.u)
+    return isempty(searchsorted(A.t, t)) ? zero(u₁) : fill(typed_nan(A.u), size(u₁))
 end
 
 # QuadraticSpline Interpolation

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -215,9 +215,6 @@ function _extrapolate_integral_right(A::SmoothedConstantInterpolation, t)
         end
         out
     elseif extrapolation_right == ExtrapolationType.Linear
-        slope = derivative(A, last(A.t))
-        Δt = t - last(A.t)
-        (_last(A.u) + slope * Δt / 2) * Δt
         _extrapolate_other(A, t, A.extrapolation_right)
     elseif extrapolation_right == ExtrapolationType.Periodic
         t_, n = transformation_periodic(A, t)

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -41,12 +41,28 @@ function integral(A::AbstractInterpolation, t::Number)
     return integral(A, first(A.t), t)
 end
 
+# For array valued `u` each entry of `A.I` is itself an array, which has no
+# `zero`, so build the accumulator from the shape of a data point instead.
+_integral_zero(A) = _integral_zero(A.u, eltype(A.I))
+_integral_zero(::Any, ::Type{T}) where {T} = zero(T)
+function _integral_zero(u::AbstractArray{<:Number}, ::Type{T}) where {T <: AbstractArray}
+    return zeros(eltype(T), size(_first(u)))
+end
+
+# `total` is allocated by `_integral_zero` for this call, so array valued
+# integrals accumulate into it rather than allocating once per interval.
+_add_integral(total::Number, Δ) = total + Δ
+_add_integral(total::AbstractArray, Δ) = (total .+= Δ)
+
+_sub_integral(total::Number, Δ) = total - Δ
+_sub_integral(total::AbstractArray, Δ) = (total .-= Δ)
+
 function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     !hasfield(typeof(A), :I) && throw(IntegralNotFoundError())
 
     if t1 == t2
         # If the integration interval is trivial then the result is 0
-        return zero(eltype(A.I))
+        return _integral_zero(A)
     elseif t1 > t2
         # Make sure that t1 < t2
         return -integral(A, t2, t1)
@@ -57,8 +73,8 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     # the index less than t2
     idx2 = get_idx(A, t2, 0; idx_shift = -1, side = :first)
 
-    total = isa(A.u, AbstractVector) ? zero(eltype(A.I)) : zero(A.u[:, 1])
-    
+    total = _integral_zero(A)
+
     # Lower potentially incomplete interval
     if t1 < first(A.t)
         if t2 < first(A.t)
@@ -67,9 +83,9 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
         end
 
         idx1 -= 1 # Make sure lowest complete interval is included
-        total += _extrapolate_integral_left(A, t1)
+        total = _add_integral(total, _extrapolate_integral_left(A, t1))
     else
-        total += _integral(A, idx1, t1, A.t[idx1 + 1])
+        total = _add_integral(total, _integral(A, idx1, t1, A.t[idx1 + 1]))
     end
 
     # Upper potentially incomplete interval
@@ -80,9 +96,9 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
         end
 
         idx2 += 1 # Make sure highest complete interval is included
-        total += _extrapolate_integral_right(A, t2)
+        total = _add_integral(total, _extrapolate_integral_right(A, t2))
     else
-        total += _integral(A, idx2, A.t[idx2], t2)
+        total = _add_integral(total, _integral(A, idx2, A.t[idx2], t2))
     end
 
     if idx1 == idx2
@@ -92,14 +108,14 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     # Complete intervals
     if A.cache_parameters
         if idx2 > 1
-            total += A.I[idx2 - 1]
+            total = _add_integral(total, A.I[idx2 - 1])
         end
         if idx1 > 0
-            total -= A.I[idx1]
+            total = _sub_integral(total, A.I[idx1])
         end
     else
         for idx in (idx1 + 1):(idx2 - 1)
-            total += _integral(A, idx, A.t[idx], A.t[idx + 1])
+            total = _add_integral(total, _integral(A, idx, A.t[idx], A.t[idx + 1]))
         end
     end
 
@@ -115,7 +131,8 @@ function _extrapolate_integral_left(A, t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = derivative(A, first(A.t))
         Δt = first(A.t) - t
-        (_first(A.u) - slope * Δt / 2) * Δt
+        u₁ = _first(A.u)
+        @. (u₁ - slope * Δt / 2) * Δt
     elseif extrapolation_left == ExtrapolationType.Extension
         _integral(A, 1, t, first(A.t))
     elseif extrapolation_left == ExtrapolationType.Periodic
@@ -149,7 +166,8 @@ function _extrapolate_integral_right(A, t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = derivative(A, last(A.t))
         Δt = t - last(A.t)
-        (_last(A.u) + slope * Δt / 2) * Δt
+        uₙ = _last(A.u)
+        @. (uₙ + slope * Δt / 2) * Δt
     elseif extrapolation_right == ExtrapolationType.Extension
         _integral(A, length(A.t) - 1, last(A.t), t)
     elseif extrapolation_right == ExtrapolationType.Periodic
@@ -224,47 +242,22 @@ function _extrapolate_integral_right(A::SmoothedConstantInterpolation, t)
 end
 
 function _integral(
-        A::LinearInterpolation{<:AbstractVector{<:Number}},
+        A::LinearInterpolation{<:AbstractArray{<:Number}},
         idx::Number, t1::Number, t2::Number
     )
     slope = get_parameters(A, idx)
-    u_mean = A.u[idx] + slope * ((t1 + t2) / 2 - A.t[idx])
-    return u_mean * (t2 - t1)
-end
-
-function _integral(
-        A::LinearInterpolation{<:AbstractMatrix{<:Number}},
-        idx::Number, t1::Number, t2::Number
-    )
-    slope = get_parameters(A, idx)
-    u_mean = A.u[:, idx] + slope * ((t1 + t2) / 2 - A.t[idx])
-    return u_mean * (t2 - t1)
-end
-
-function _integral(
-        A::ConstantInterpolation{<:AbstractVector{<:Number}}, idx::Number, t1::Number, t2::Number
-    )
+    uᵢ = _u_view(A.u, idx)
+    Δt_mean = (t1 + t2) / 2 - A.t[idx]
     Δt = t2 - t1
-    if A.dir === :left
-        # :left means that value to the left is used for interpolation
-        return A.u[idx] * Δt
-    else
-        # :right means that value to the right is used for interpolation
-        return A.u[idx + 1] * Δt
-    end
+    return @. (uᵢ + slope * Δt_mean) * Δt
 end
 
 function _integral(
-        A::ConstantInterpolation{<:AbstractMatrix{<:Number}}, idx::Number, t1::Number, t2::Number
+        A::ConstantInterpolation{<:AbstractArray{<:Number}}, idx::Number, t1::Number, t2::Number
     )
-    Δt = t2 - t1
-    if A.dir === :left
-        # :left means that value to the left is used for interpolation
-        return A.u[:, idx] * Δt
-    else
-        # :right means that value to the right is used for interpolation
-        return A.u[:, idx + 1] * Δt
-    end
+    # :left/:right means that the value to the left/right is used for interpolation
+    uᵢ = _u_view(A.u, A.dir === :left ? idx : idx + 1)
+    return uᵢ * (t2 - t1)
 end
 
 function _integral(
@@ -304,29 +297,17 @@ function _integral(
 end
 
 function _integral(
-        A::QuadraticInterpolation{<:AbstractVector{<:Number}},
+        A::QuadraticInterpolation{<:AbstractArray{<:Number}},
         idx::Number, t1::Number, t2::Number
     )
     α, β = get_parameters(A, idx)
-    uᵢ = A.u[idx]
+    uᵢ = _u_view(A.u, idx)
     tᵢ = A.t[idx]
     t1_rel = t1 - tᵢ
     t2_rel = t2 - tᵢ
     Δt = t2 - t1
-    return Δt * (α * (t2_rel^2 + t1_rel * t2_rel + t1_rel^2) / 3 + β * (t2_rel + t1_rel) / 2 + uᵢ)
-end
-
-function _integral(
-        A::QuadraticInterpolation{<:AbstractMatrix{<:Number}},
-        idx::Number, t1::Number, t2::Number
-    )
-    α, β = get_parameters(A, idx)
-    uᵢ = A.u[:, idx]
-    tᵢ = A.t[idx]
-    t1_rel = t1 - tᵢ
-    t2_rel = t2 - tᵢ
-    Δt = t2 - t1
-    return Δt * (α * (t2_rel^2 + t1_rel * t2_rel + t1_rel^2) / 3 + β * (t2_rel + t1_rel) / 2 + uᵢ)
+    return @. Δt *
+        (α * (t2_rel^2 + t1_rel * t2_rel + t1_rel^2) / 3 + β * (t2_rel + t1_rel) / 2 + uᵢ)
 end
 
 function _integral(

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -57,8 +57,8 @@ function integral(A::AbstractInterpolation, t1::Number, t2::Number)
     # the index less than t2
     idx2 = get_idx(A, t2, 0; idx_shift = -1, side = :first)
 
-    total = zero(eltype(A.I))
-
+    total = isa(A.u, AbstractVector) ? zero(eltype(A.I)) : zero(A.u[:, 1])
+    
     # Lower potentially incomplete interval
     if t1 < first(A.t)
         if t2 < first(A.t)
@@ -111,11 +111,11 @@ function _extrapolate_integral_left(A, t)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
-        first(A.u) * (first(A.t) - t)
+        _first(A.u) * (first(A.t) - t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = derivative(A, first(A.t))
         Δt = first(A.t) - t
-        (first(A.u) - slope * Δt / 2) * Δt
+        (_first(A.u) - slope * Δt / 2) * Δt
     elseif extrapolation_left == ExtrapolationType.Extension
         _integral(A, 1, t, first(A.t))
     elseif extrapolation_left == ExtrapolationType.Periodic
@@ -145,11 +145,11 @@ function _extrapolate_integral_right(A, t)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
-        last(A.u) * (t - last(A.t))
+        _last(A.u) * (t - last(A.t))
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = derivative(A, last(A.t))
         Δt = t - last(A.t)
-        (last(A.u) + slope * Δt / 2) * Δt
+        (_last(A.u) + slope * Δt / 2) * Δt
     elseif extrapolation_right == ExtrapolationType.Extension
         _integral(A, length(A.t) - 1, last(A.t), t)
     elseif extrapolation_right == ExtrapolationType.Periodic
@@ -199,7 +199,7 @@ function _extrapolate_integral_right(A::SmoothedConstantInterpolation, t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = derivative(A, last(A.t))
         Δt = t - last(A.t)
-        (last(A.u) + slope * Δt / 2) * Δt
+        (_last(A.u) + slope * Δt / 2) * Δt
         _extrapolate_other(A, t, A.extrapolation_right)
     elseif extrapolation_right == ExtrapolationType.Periodic
         t_, n = transformation_periodic(A, t)
@@ -233,6 +233,15 @@ function _integral(
 end
 
 function _integral(
+        A::LinearInterpolation{<:AbstractMatrix{<:Number}},
+        idx::Number, t1::Number, t2::Number
+    )
+    slope = get_parameters(A, idx)
+    u_mean = A.u[:, idx] + slope * ((t1 + t2) / 2 - A.t[idx])
+    return u_mean * (t2 - t1)
+end
+
+function _integral(
         A::ConstantInterpolation{<:AbstractVector{<:Number}}, idx::Number, t1::Number, t2::Number
     )
     Δt = t2 - t1
@@ -242,6 +251,19 @@ function _integral(
     else
         # :right means that value to the right is used for interpolation
         return A.u[idx + 1] * Δt
+    end
+end
+
+function _integral(
+        A::ConstantInterpolation{<:AbstractMatrix{<:Number}}, idx::Number, t1::Number, t2::Number
+    )
+    Δt = t2 - t1
+    if A.dir === :left
+        # :left means that value to the left is used for interpolation
+        return A.u[:, idx] * Δt
+    else
+        # :right means that value to the right is used for interpolation
+        return A.u[:, idx + 1] * Δt
     end
 end
 
@@ -287,6 +309,19 @@ function _integral(
     )
     α, β = get_parameters(A, idx)
     uᵢ = A.u[idx]
+    tᵢ = A.t[idx]
+    t1_rel = t1 - tᵢ
+    t2_rel = t2 - tᵢ
+    Δt = t2 - t1
+    return Δt * (α * (t2_rel^2 + t1_rel * t2_rel + t1_rel^2) / 3 + β * (t2_rel + t1_rel) / 2 + uᵢ)
+end
+
+function _integral(
+        A::QuadraticInterpolation{<:AbstractMatrix{<:Number}},
+        idx::Number, t1::Number, t2::Number
+    )
+    α, β = get_parameters(A, idx)
+    uᵢ = A.u[:, idx]
     tᵢ = A.t[idx]
     t1_rel = t1 - tᵢ
     t2_rel = t2 - tᵢ

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1674,7 +1674,7 @@ function _first(u::AbstractVector)
 end
 
 function _first(u::AbstractMatrix)
-    u[:,1]
+    u[:, 1]
 end
 
 function _last(u::AbstractVector)
@@ -1682,5 +1682,5 @@ function _last(u::AbstractVector)
 end
 
 function _last(u::AbstractMatrix)
-    u[:,end]
+    u[:, end]
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1667,20 +1667,3 @@ function _interpolate(A::SmoothArcLengthInterpolation, t::Number, iguess)
 
     return out
 end
-
-#get first and last data point from both vector and matrix u
-function _first(u::AbstractVector)
-    first(u)
-end
-
-function _first(u::AbstractMatrix)
-    u[:, 1]
-end
-
-function _last(u::AbstractVector)
-    last(u)
-end
-
-function _last(u::AbstractMatrix)
-    u[:, end]
-end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -14,10 +14,10 @@ function _extrapolate_left(A, t)
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
         slope = _derivative(A, first(A.t), 1)
-        first(A.u) + zero(slope * t)
+        _first(A.u) + zero(slope * t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = _derivative(A, first(A.t), 1)
-        first(A.u) + slope * (t - first(A.t))
+        _first(A.u) + slope * (t - first(A.t))
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -29,10 +29,10 @@ function _extrapolate_right(A, t)
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
         slope = _derivative(A, last(A.t), length(A.t))
-        last(A.u) + zero(slope * t)
+        _last(A.u) + zero(slope * t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = _derivative(A, last(A.t), length(A.t))
-        last(A.u) + slope * (t - last(A.t))
+        _last(A.u) + slope * (t - last(A.t))
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -133,7 +133,7 @@ function _extrapolate_left(A::ConstantInterpolation, t)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        first(A.u)
+        _first(A.u)
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -144,7 +144,7 @@ function _extrapolate_right(A::ConstantInterpolation, t)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        last(A.u)
+        _last(A.u)
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -1666,4 +1666,21 @@ function _interpolate(A::SmoothArcLengthInterpolation, t::Number, iguess)
     end
 
     return out
+end
+
+#get first and last data point from both vector and matrix u
+function _first(u::AbstractVector)
+    first(u)
+end
+
+function _first(u::AbstractMatrix)
+    u[:,1]
+end
+
+function _last(u::AbstractVector)
+    last(u)
+end
+
+function _last(u::AbstractMatrix)
+    u[:,end]
 end

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -14,10 +14,13 @@ function _extrapolate_left(A, t)
         throw(LeftExtrapolationError())
     elseif extrapolation_left == ExtrapolationType.Constant
         slope = _derivative(A, first(A.t), 1)
-        _first(A.u) + zero(slope * t)
+        u₁ = _first(A.u)
+        @. u₁ + zero(slope * t)
     elseif extrapolation_left == ExtrapolationType.Linear
         slope = _derivative(A, first(A.t), 1)
-        _first(A.u) + slope * (t - first(A.t))
+        u₁ = _first(A.u)
+        Δt = t - first(A.t)
+        @. u₁ + slope * Δt
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -29,10 +32,13 @@ function _extrapolate_right(A, t)
         throw(RightExtrapolationError())
     elseif extrapolation_right == ExtrapolationType.Constant
         slope = _derivative(A, last(A.t), length(A.t))
-        _last(A.u) + zero(slope * t)
+        uₙ = _last(A.u)
+        @. uₙ + zero(slope * t)
     elseif extrapolation_right == ExtrapolationType.Linear
         slope = _derivative(A, last(A.t), length(A.t))
-        _last(A.u) + slope * (t - last(A.t))
+        uₙ = _last(A.u)
+        Δt = t - last(A.t)
+        @. uₙ + slope * Δt
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -133,7 +139,7 @@ function _extrapolate_left(A::ConstantInterpolation, t)
     return if extrapolation_left == ExtrapolationType.None
         throw(LeftExtrapolationError())
     elseif extrapolation_left in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        _first(A.u)
+        _u_point(A.u, firstindex(A.t))
     else
         _extrapolate_other(A, t, extrapolation_left)
     end
@@ -144,7 +150,7 @@ function _extrapolate_right(A::ConstantInterpolation, t)
     return if extrapolation_right == ExtrapolationType.None
         throw(RightExtrapolationError())
     elseif extrapolation_right in (ExtrapolationType.Constant, ExtrapolationType.Linear)
-        _last(A.u)
+        _u_point(A.u, lastindex(A.t))
     else
         _extrapolate_other(A, t, extrapolation_right)
     end
@@ -315,8 +321,8 @@ function _interpolate(A::LinearInterpolation{<:AbstractArray}, t::Number, iguess
     idx = get_idx(A, t, iguess)
     Δt = t - A.t[idx]
     slope = get_parameters(A, idx)
-    ax = axes(A.u)[1:(end - 1)]
-    return A.u[ax..., idx] + slope * Δt
+    uᵢ = _u_view(A.u, idx)
+    return @. uᵢ + slope * Δt
 end
 
 function (A::LinearInterpolation{<:AbstractVector{<:Number}})(
@@ -437,9 +443,8 @@ function _interpolate(A::QuadraticInterpolation, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt = t - A.t[idx]
     α, β = get_parameters(A, idx)
-    out = A.u isa AbstractMatrix ? A.u[:, idx] : A.u[idx]
-    out += @. Δt * (α * Δt + β)
-    return out
+    uᵢ = _u_view(A.u, idx)
+    return @. uᵢ + Δt * (α * Δt + β)
 end
 
 function (A::QuadraticInterpolation{<:AbstractVector{<:Number}})(

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -573,19 +573,18 @@ end
 
 get_transition_ts(A::AbstractInterpolation) = A.t
 
-#get first and last data point from both vector and matrix u
-function _first(u::AbstractVector)
-    first(u)
-end
+# Data points sit in the last dimension of `u`, unless `u` holds one value per
+# data point. `_u_view` aliases `u` and is meant for expressions that build a new
+# result from it; `_u_point` returns what `_interpolate` would, so it is safe to
+# hand back to the caller.
+_u_view(u::AbstractVector, idx) = u[idx]
+_u_view(u::AbstractArray, idx) = selectdim(u, ndims(u), idx)
 
-function _first(u::AbstractMatrix)
-    u[:, 1]
-end
+_u_point(u::AbstractVector, idx) = u[idx]
+_u_point(u::AbstractArray, idx) = copy(_u_view(u, idx))
 
-function _last(u::AbstractVector)
-    last(u)
-end
+_first(u::AbstractVector) = first(u)
+_first(u::AbstractArray) = _u_view(u, firstindex(u, ndims(u)))
 
-function _last(u::AbstractMatrix)
-    u[:, end]
-end
+_last(u::AbstractVector) = last(u)
+_last(u::AbstractArray) = _u_view(u, lastindex(u, ndims(u)))

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -572,3 +572,20 @@ function get_transition_ts(A::SmoothedConstantInterpolation)
 end
 
 get_transition_ts(A::AbstractInterpolation) = A.t
+
+#get first and last data point from both vector and matrix u
+function _first(u::AbstractVector)
+    first(u)
+end
+
+function _first(u::AbstractMatrix)
+    u[:, 1]
+end
+
+function _last(u::AbstractVector)
+    last(u)
+end
+
+function _last(u::AbstractMatrix)
+    u[:, end]
+end

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -18,19 +18,23 @@ function safe_diff(b, a::T) where {T}
     return isequal(b, a) ? zero(T) : b - a
 end
 
-function linear_interpolation_parameters(u::AbstractArray{T, N}, t, idx) where {T, N}
-    Δu = if N > 1
-        ax = axes(u)
-        safe_diff.(
-            u[ax[1:(end - 1)]..., (idx + 1)], u[ax[1:(end - 1)]..., idx]
-        )
-    else
-        safe_diff(u[idx + 1], u[idx])
-    end
+function linear_interpolation_parameters(u::AbstractVector, t, idx)
+    Δu = safe_diff(u[idx + 1], u[idx])
     Δt = t[idx + 1] - t[idx]
     slope = Δu / Δt
     slope = iszero(Δt) ? zero(slope) : slope
     return slope
+end
+
+function linear_interpolation_parameters(u::AbstractArray, t, idx)
+    u₀ = _u_view(u, idx)
+    u₁ = _u_view(u, idx + 1)
+    Δt = t[idx + 1] - t[idx]
+    return if iszero(Δt)
+        @. zero(safe_diff(u₁, u₀) / oneunit(Δt))
+    else
+        @. safe_diff(u₁, u₀) / Δt
+    end
 end
 
 struct SmoothedConstantParameterCache{dType, cType}
@@ -104,24 +108,24 @@ function quadratic_interpolation_parameters(u, t, idx, mode)
     end
 
     t₀ = t[idx]
-    u₀ = u isa AbstractMatrix ? view(u, :, idx) : u[idx]
+    u₀ = _u_view(u, idx)
 
     t₁ = t[idx + 1]
-    u₁ = u isa AbstractMatrix ? view(u, :, idx + 1) : u[idx + 1]
+    u₁ = _u_view(u, idx + 1)
 
     t₂, u₂ = if mode == :Backward
-        t[idx - 1], u isa AbstractMatrix ? view(u, :, idx - 1) : u[idx - 1]
+        t[idx - 1], _u_view(u, idx - 1)
     else
-        t[idx + 2], u isa AbstractMatrix ? view(u, :, idx + 2) : u[idx + 2]
+        t[idx + 2], _u_view(u, idx + 2)
     end
 
     Δt₁ = t₁ - t₀
     Δt₂ = t₂ - t₀
     Δt = t₂ - t₁
-    s₁ = (u₁ - u₀) / Δt₁
-    s₂ = (u₂ - u₀) / Δt₂
-    α = (s₂ - s₁) / Δt
-    β = s₁ - α * Δt₁
+    s₁ = @. (u₁ - u₀) / Δt₁
+    s₂ = @. (u₂ - u₀) / Δt₂
+    α = @. (s₂ - s₁) / Δt
+    β = @. s₁ - α * Δt₁
 
     return α, β
 end

--- a/test/extrapolation_tests.jl
+++ b/test/extrapolation_tests.jl
@@ -97,12 +97,58 @@ end
     @test @inferred(A([t_eval])) == [0.0u"m"]
     @test A([t_eval]) isa Vector{typeof(0.0u"m")}
 
-    # Right constant extrapolation
+    # Right linear extrapolation
     A = LinearInterpolation(u_un, t_un; extrapolation_right = ExtrapolationType.Linear)
     t_eval = 3.0u"s"
     @test @inferred(A(t_eval)) == 3.0u"m"
     @test @inferred(A([t_eval])) == [3.0u"m"]
     @test A([t_eval]) isa Vector{typeof(3.0u"m")}
+end
+
+@testset "Constant Interpolation" begin
+    u = [1.0, 2.0]
+    t = [1.0, 2.0]
+
+    #test_extrapolation(ConstantInterpolation, u, t)
+
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == 1.0
+    @test DataInterpolations.derivative(A, t_eval) == 0.0
+    @test DataInterpolations.derivative(A, t_eval, 2) == 0.0
+    @test DataInterpolations.integral(A, t_eval) == -1.0
+    t_eval = 3.0
+
+    # Right extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == 2.0
+    @test DataInterpolations.derivative(A, t_eval) == 0.0
+    @test DataInterpolations.derivative(A, t_eval, 2) == 0.0
+    @test DataInterpolations.integral(A, t_eval) == 3.0
+
+    #Matrix u tests
+    u = [1.0 2.0; 1.0 2.0]
+    t = [1.0, 2.0]
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == [1.0, 1.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [-1.0, -1.0]
+
+    # Right extrapolation
+    A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == [2.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [3.0, 3.0]
+        
 end
 
 @testset "Linear Interpolation" begin
@@ -130,6 +176,45 @@ end
         @test DataInterpolations.integral(A, t_eval) == 4.0
         t_eval = 0.0
     end
+
+    #Matrix u tests
+    u = [1.0 2.0; 2.0 5.0]
+    t = [1.0, 2.0]
+    extrapolation_type = ExtrapolationType.Constant
+    # Left extrapolation
+    A = LinearInterpolation(u, t; extrapolation_left = extrapolation_type)
+    t_eval = 0.0
+    @test A(t_eval) == [1.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [-1.0, -2.0]
+
+    # Right extrapolation
+    A = LinearInterpolation(u, t; extrapolation_right = extrapolation_type)
+    t_eval = 3.0
+    @test A(t_eval) == [2.0, 5.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) == [3.5, 8.5]
+    
+    for extrapolation_type in [ExtrapolationType.Linear, ExtrapolationType.Extension]
+        # Left extrapolation
+        A = LinearInterpolation(u, t; extrapolation_left = extrapolation_type)
+        t_eval = 0.0
+        @test A(t_eval) == [0.0, -1.0]
+        @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
+        @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+        @test DataInterpolations.integral(A, t_eval) == [-0.5, -0.5]
+        
+        # Right extrapolation
+        A = LinearInterpolation(u, t; extrapolation_right = extrapolation_type)
+        t_eval = 3.0
+        @test A(t_eval) == [3.0, 8.0]
+        @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
+        @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+        @test DataInterpolations.integral(A, t_eval) == [4.0, 10.0]
+    end
+        
 end
 
 @testset "Quadratic Interpolation" begin
@@ -171,4 +256,60 @@ end
     @test DataInterpolations.derivative(A, t_eval) == df(t_eval)
     @test DataInterpolations.derivative(A, t_eval, 2) == -3
     @test DataInterpolations.integral(A, t_eval) ≈ 5.25
+
+    #Matrix u tests
+    u = [1.0 3.0 2.0; 1.0 3.0 2.0]
+    t = 1:3
+
+    test_extrapolation(QuadraticInterpolation, u, t)
+
+    # Constant left extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Constant)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [1.0, 1.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) ≈ [-1.0, -1.0]
+
+    # Constant right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Constant)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [2.0, 2.0]
+    @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t[end], t_eval) ≈ [2.0, 2.0]
+
+    # Linear left extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Linear)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [-2.5,-2.5]
+    @test DataInterpolations.derivative(A, t_eval) == [3.5, 3.5]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t_eval) ≈ [0.75, 0.75]
+
+    # Linear right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Linear)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [-0.5, -0.5]
+    @test DataInterpolations.derivative(A, t_eval) == [-2.5, -2.5]
+    @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
+    @test DataInterpolations.integral(A, t[end], t_eval) ≈ [0.75, 0.75]
+
+    # Extension left extrapolation
+    f = t -> (-3t^2 + 13t - 8) / 2
+    df = t -> (-6t + 13) / 2
+    A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Extension)
+    t_eval = 0.0
+    @test A(t_eval) ≈ [-4.0, -4.0]
+    @test DataInterpolations.derivative(A, t_eval) == df(t_eval) * ones(2)
+    @test DataInterpolations.derivative(A, t_eval, 2) == [-3, -3]
+    @test DataInterpolations.integral(A, t_eval) ≈ [1.25, 1.25]
+
+    # Extension right extrapolation
+    A = QuadraticInterpolation(u, t; extrapolation_right = ExtrapolationType.Extension)
+    t_eval = 4.0
+    @test A(t_eval) ≈ [-2.0, -2.0]
+    @test DataInterpolations.derivative(A, t_eval) == df(t_eval) * ones(2)
+    @test DataInterpolations.derivative(A, t_eval, 2) == [-3, -3]
+    @test DataInterpolations.integral(A, t_eval) ≈ [5.25, 5.25]
 end

--- a/test/extrapolation_tests.jl
+++ b/test/extrapolation_tests.jl
@@ -109,8 +109,6 @@ end
     u = [1.0, 2.0]
     t = [1.0, 2.0]
 
-    #test_extrapolation(ConstantInterpolation, u, t)
-
     extrapolation_type = ExtrapolationType.Constant
     # Left extrapolation
     A = ConstantInterpolation(u, t; extrapolation_left = extrapolation_type)
@@ -119,7 +117,6 @@ end
     @test DataInterpolations.derivative(A, t_eval) == 0.0
     @test DataInterpolations.derivative(A, t_eval, 2) == 0.0
     @test DataInterpolations.integral(A, t_eval) == -1.0
-    t_eval = 3.0
 
     # Right extrapolation
     A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
@@ -140,6 +137,7 @@ end
     @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
     @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
     @test DataInterpolations.integral(A, t_eval) == [-1.0, -1.0]
+    @test DataInterpolations.integral(A, t_eval, t_eval) == [0.0, 0.0]
 
     # Right extrapolation
     A = ConstantInterpolation(u, t; extrapolation_right = extrapolation_type)
@@ -148,7 +146,11 @@ end
     @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
     @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
     @test DataInterpolations.integral(A, t_eval) == [3.0, 3.0]
-        
+    @test DataInterpolations.integral(A, t_eval, t_eval) == [0.0, 0.0]
+
+    # The extrapolated value must not alias `u`
+    A(t_eval) .= 0.0
+    @test A.u == [1.0 2.0; 1.0 2.0]
 end
 
 @testset "Linear Interpolation" begin
@@ -196,7 +198,7 @@ end
     @test DataInterpolations.derivative(A, t_eval) == [0.0, 0.0]
     @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
     @test DataInterpolations.integral(A, t_eval) == [3.5, 8.5]
-    
+
     for extrapolation_type in [ExtrapolationType.Linear, ExtrapolationType.Extension]
         # Left extrapolation
         A = LinearInterpolation(u, t; extrapolation_left = extrapolation_type)
@@ -205,7 +207,8 @@ end
         @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
         @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
         @test DataInterpolations.integral(A, t_eval) == [-0.5, -0.5]
-        
+        @test DataInterpolations.integral(A, t_eval, t_eval) == [0.0, 0.0]
+
         # Right extrapolation
         A = LinearInterpolation(u, t; extrapolation_right = extrapolation_type)
         t_eval = 3.0
@@ -213,8 +216,8 @@ end
         @test DataInterpolations.derivative(A, t_eval) == [1.0, 3.0]
         @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
         @test DataInterpolations.integral(A, t_eval) == [4.0, 10.0]
+        @test DataInterpolations.integral(A, t_eval, t_eval) == [0.0, 0.0]
     end
-        
 end
 
 @testset "Quadratic Interpolation" begin
@@ -282,7 +285,7 @@ end
     # Linear left extrapolation
     A = QuadraticInterpolation(u, t; extrapolation_left = ExtrapolationType.Linear)
     t_eval = 0.0
-    @test A(t_eval) ≈ [-2.5,-2.5]
+    @test A(t_eval) ≈ [-2.5, -2.5]
     @test DataInterpolations.derivative(A, t_eval) == [3.5, 3.5]
     @test DataInterpolations.derivative(A, t_eval, 2) == [0.0, 0.0]
     @test DataInterpolations.integral(A, t_eval) ≈ [0.75, 0.75]
@@ -312,4 +315,47 @@ end
     @test DataInterpolations.derivative(A, t_eval) == df(t_eval) * ones(2)
     @test DataInterpolations.derivative(A, t_eval, 2) == [-3, -3]
     @test DataInterpolations.integral(A, t_eval) ≈ [5.25, 5.25]
+end
+
+# The number of allocations one array costs is a Julia version detail, so the
+# budgets below are expressed in bytes relative to one result array. The counting
+# sits behind a function barrier to keep the test scope's boxing out of it.
+function result_bytes(u)
+    uᵢ = @view u[:, 1]
+    uᵢ .+ 1.0
+    return @allocated(uᵢ .+ 1.0)
+end
+
+function extrapolation_allocations(A, t_eval)
+    A(t_eval)
+    DataInterpolations.derivative(A, t_eval)
+    DataInterpolations.integral(A, t_eval)
+    return (
+        @allocated(A(t_eval)),
+        @allocated(DataInterpolations.derivative(A, t_eval)),
+        @allocated(DataInterpolations.integral(A, t_eval)),
+    )
+end
+
+# Extrapolating matrix `u` builds one array per value it computes; a slice or an
+# unfused broadcast creeping back in shows up as several arrays per value.
+@testset "Matrix u extrapolation allocations" begin
+    u = [1.0 3.0 2.0; 2.0 5.0 7.0]
+    t = [1.0, 2.0, 3.0]
+    result = result_bytes(u)
+
+    for method in (ConstantInterpolation, LinearInterpolation, QuadraticInterpolation),
+            extrapolation_type in (
+                ExtrapolationType.Constant, ExtrapolationType.Linear,
+                ExtrapolationType.Extension,
+            )
+
+        A = method(u, t; extrapolation = extrapolation_type, cache_parameters = true)
+        for t_eval in (0.0, 4.0)
+            n_eval, n_derivative, n_integral = extrapolation_allocations(A, t_eval)
+            @test n_eval <= 2result
+            @test n_derivative <= 2result
+            @test n_integral <= 6result
+        end
+    end
 end


### PR DESCRIPTION
> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Continues https://github.com/SciML/DataInterpolations.jl/pull/563 by @jbiffl (matrix `u` support for `ConstantInterpolation`, `LinearInterpolation` and `QuadraticInterpolation` extrapolation, fixing #561). That PR's commits are included unchanged and rebased onto current master; this adds the follow-up asked for in https://github.com/SciML/DataInterpolations.jl/pull/563#discussion_r3700440903 ("You don't need to slice that?").

## The problem

Reaching a data point out of a matrix `u` was done by copying a column — `u[:, idx]`, `u[:, 1]`, `u[:, end]` — and the arithmetic consuming it was left unfused, so each intermediate materialised its own array. A single extrapolated value cost up to 15 arrays where 1 is needed.

## After

Measured with `@allocated`, `u = [1.0 3.0 2.0; 2.0 5.0 7.0]`, `cache_parameters = true`, Julia 1.11. One result column is 80 bytes.

| | eval | derivative | integral |
| --- | --- | --- | --- |
| #563 as-is | 240–1200 B | 240–880 B | 880–2768 B |
| this PR | 80–160 B | 0–80 B | 240–400 B |

`eval` and `derivative` are down to the single result array, except where a parameter itself has to be computed (`QuadraticInterpolation`'s slope under `Constant`/`Linear` extrapolation) — that is a second genuinely-computed value, not a copy. `integral` composes 3–5 array-valued terms and allocates one array each; going below that would need an in-place `_integral!`, which is a larger change.

Vector `u` is unaffected: still 0 allocations, and the same runtime as master (BenchmarkTools sweep over 997 query points for `Constant`/`Linear`/`Quadratic` × `cache_parameters`, both trees, differences within noise).

## What changed

  - `_u_view` reaches the data point at an index without copying (`selectdim` on the last dimension, or plain indexing when `u` holds one value per point). `_first`/`_last` are defined in terms of it. `_u_point` is the copying variant, used only where the value is returned to the caller — `ConstantInterpolation`'s extrapolation, which must not hand back a view into `u`.
  - The expressions that consume them are fused (`@.`) in `_extrapolate_left`/`_extrapolate_right`, `_extrapolate_derivative_*`, `_extrapolate_integral_*`, `_interpolate` and `_derivative`.
  - The duplicated `_integral` methods are gone. `{<:AbstractVector{<:Number}}` and `{<:AbstractMatrix{<:Number}}` differed only in how they indexed the data point, so each collapses into one `{<:AbstractArray{<:Number}}` method — same type coverage, no slice.
  - `integral` accumulates into its own result array rather than allocating one per interval.
  - `linear_interpolation_parameters` and `quadratic_interpolation_parameters` take views instead of copies.
  - `SmoothedConstantInterpolation`'s linear right-extrapolation branch computed a value and discarded it before delegating; removed.

## Fixes along the way

  - `integral(A, t, t)` on array-valued `u` called `zero(eltype(A.I))`, where `eltype(A.I)` is an array type — `MethodError`. It now returns a zero array of one data point's shape.
  - Left/right extrapolation for `u` with more than two dimensions did `first(A.u) + slope * Δt`, adding a scalar to an array. This errored on master too; `LinearInterpolation(rand(2, 3, 4), t; extrapolation = ExtrapolationType.Linear)(0.0)` now works, as does `integral` on it.

## Tests

  - `integral(A, t, t)` for matrix `u` in the `ConstantInterpolation` and `LinearInterpolation` sets.
  - An aliasing check that `ConstantInterpolation`'s extrapolated value does not share memory with `u`.
  - `"Matrix u extrapolation allocations"`: budgets each of eval/derivative/integral against the byte cost of one result array, so a reintroduced slice or unfused broadcast fails the suite. Budgets verified on 1.10, 1.11 and 1.12 — the byte counts are identical across all three.
  - Removed the commented-out `test_extrapolation(ConstantInterpolation, u, t)` and the stray assignments/trailing whitespace from #563.

`test_extrapolation(ConstantInterpolation, u, t)` still cannot be enabled, but not because of anything here: `ConstantInterpolation`'s `integral` disagrees with the interpolation outside the data range on master, for vector `u` as much as matrix `u`. Filed separately as https://github.com/SciML/DataInterpolations.jl/issues/572.

## Checklist

  - [x] Appropriate tests were added
  - [x] Any code changes were done in a way that does not break public API
  - [x] All documentation related to code changes were updated
  - [x] The new code follows the [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and [COLPRAC](https://github.com/SciML/COLPRAC)
  - [x] Any new documentation only uses public API
