### PR TITLE
Fix ConstantInterpolation integral outside the data range

### DIFF
--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -135,15 +135,20 @@ function _extrapolate_integral_left(A, t)
         @. (u₁ - slope * Δt / 2) * Δt
     elseif extrapolation_left == ExtrapolationType.Extension
         _integral(A, 1, t, first(A.t))
-    elseif extrapolation_left == ExtrapolationType.Periodic
+    else
+        _extrapolate_integral_other_left(A, t, extrapolation_left)
+    end
+end
+
+function _extrapolate_integral_other_left(A, t, extrapolation_left)
+    return if extrapolation_left == ExtrapolationType.Periodic
         t_, n = transformation_periodic(A, t)
         out = -integral(A, t_)
         if !iszero(n)
             out -= n * integral(A, first(A.t), last(A.t))
         end
         out
-    else
-        # extrapolation_left == ExtrapolationType.Reflective
+    elseif extrapolation_left == ExtrapolationType.Reflective
         t_, n = transformation_reflective(A, t)
         out = if isodd(n)
             -integral(A, t_, last(A.t))
@@ -154,6 +159,8 @@ function _extrapolate_integral_left(A, t)
             out -= n * integral(A, first(A.t), last(A.t))
         end
         out
+    else
+        throw(ExtrapolationNotImplementedError())
     end
 end
 
@@ -170,15 +177,20 @@ function _extrapolate_integral_right(A, t)
         @. (uₙ + slope * Δt / 2) * Δt
     elseif extrapolation_right == ExtrapolationType.Extension
         _integral(A, length(A.t) - 1, last(A.t), t)
-    elseif extrapolation_right == ExtrapolationType.Periodic
+    else
+        _extrapolate_integral_other_right(A, t, extrapolation_right)
+    end
+end
+
+function _extrapolate_integral_other_right(A, t, extrapolation_right)
+    return if extrapolation_right == ExtrapolationType.Periodic
         t_, n = transformation_periodic(A, t)
         out = integral(A, first(A.t), t_)
         if !iszero(n)
             out += n * integral(A, first(A.t), last(A.t))
         end
         out
-    else
-        # extrapolation_right == ExtrapolationType.Reflective
+    elseif extrapolation_right == ExtrapolationType.Reflective
         t_, n = transformation_reflective(A, t)
         out = if iseven(n)
             integral(A, t_, last(A.t))
@@ -189,6 +201,40 @@ function _extrapolate_integral_right(A, t)
             out += n * integral(A, first(A.t), last(A.t))
         end
         out
+    else
+        throw(ExtrapolationNotImplementedError())
+    end
+end
+
+# `ConstantInterpolation` extrapolates with the boundary value for `Constant`, `Linear`
+# and `Extension` alike (see `_extrapolate_left`/`_extrapolate_right`), so neither the
+# generic slope-based `Linear` branch nor the boundary-interval `Extension` branch (which
+# picks a `dir`-dependent index) describes what is actually being integrated.
+function _extrapolate_integral_left(A::ConstantInterpolation, t)
+    (; extrapolation_left) = A
+    return if extrapolation_left == ExtrapolationType.None
+        throw(LeftExtrapolationError())
+    elseif extrapolation_left in (
+            ExtrapolationType.Constant, ExtrapolationType.Linear,
+            ExtrapolationType.Extension,
+        )
+        _first(A.u) * (first(A.t) - t)
+    else
+        _extrapolate_integral_other_left(A, t, extrapolation_left)
+    end
+end
+
+function _extrapolate_integral_right(A::ConstantInterpolation, t)
+    (; extrapolation_right) = A
+    return if extrapolation_right == ExtrapolationType.None
+        throw(RightExtrapolationError())
+    elseif extrapolation_right in (
+            ExtrapolationType.Constant, ExtrapolationType.Linear,
+            ExtrapolationType.Extension,
+        )
+        _last(A.u) * (t - last(A.t))
+    else
+        _extrapolate_integral_other_right(A, t, extrapolation_right)
     end
 end
 

--- a/test/extrapolation_tests.jl
+++ b/test/extrapolation_tests.jl
@@ -151,6 +151,33 @@ end
     # The extrapolated value must not alias `u`
     A(t_eval) .= 0.0
     @test A.u == [1.0 2.0; 1.0 2.0]
+
+    # issue #572: outside the data `Constant`, `Linear` and `Extension` all evaluate to
+    # the boundary value, so the integral must too — `Linear` used to pick up the `NaN`
+    # slope at a knot and `Extension` used to integrate a `dir`-dependent interval.
+    u = [1.0, 2.0, 5.0]
+    t = [1.0, 2.0, 3.0]
+    u_mat = [1.0 2.0 5.0; 2.0 3.0 1.0]
+
+    for dir in (:left, :right),
+            extrapolation_type in instances(ExtrapolationType.T)
+
+        (extrapolation_type == ExtrapolationType.None) && continue
+        @testset "extrapolation type $extrapolation_type, dir = $dir" begin
+            A = ConstantInterpolation(u, t; extrapolation = extrapolation_type, dir)
+            A_mat = ConstantInterpolation(
+                u_mat, t; extrapolation = extrapolation_type, dir
+            )
+
+            # Left of the data, right of the data, and spanning the whole range.
+            for (t1, t2) in ((-1.0, 1.0), (3.0, 5.0), (-4.0, 8.0))
+                @test DataInterpolations.integral(A, t1, t2) ≈
+                    quadgk(A, t1, t2; atol = 1.0e-12, rtol = 1.0e-12)[1]
+                @test DataInterpolations.integral(A_mat, t1, t2) ≈
+                    quadgk(τ -> A_mat(τ), t1, t2; atol = 1.0e-12, rtol = 1.0e-12)[1]
+            end
+        end
+    end
 end
 
 @testset "Linear Interpolation" begin


### PR DESCRIPTION
Fixes https://github.com/SciML/DataInterpolations.jl/issues/572 — applies the fix suggested there.

**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Problem

`integral` of a `ConstantInterpolation` disagreed with the interpolation itself outside the data range:

- `ExtrapolationType.Linear` returned `NaN` on both sides, for both `dir` settings.
- `ExtrapolationType.Extension` integrated the wrong interval's value on one side (right side for `dir = :left`, left side for `dir = :right`).

## Cause

`ConstantInterpolation` has its own `_extrapolate_left`/`_extrapolate_right`, where `Constant`, `Linear` and `Extension` all return the boundary value. The integral fell through to the generic `_extrapolate_integral_left`/`_right` instead:

- The `Linear` branch multiplies by `derivative(A, first(A.t))`, and `_derivative` for `ConstantInterpolation` returns `typed_nan` at a knot — so the whole expression is `NaN`, even though the value being integrated has no slope at all.
- The `Extension` branch integrates the boundary interval with `_integral`, which picks `A.u[idx]` for `dir === :left` and `A.u[idx + 1]` for `dir === :right`. Outside the data, evaluation clamps to `A.u[begin]`/`A.u[end]` regardless of `dir`, so one side is off by one.

## Fix

Add `_extrapolate_integral_left`/`_extrapolate_integral_right` methods for `ConstantInterpolation` that mirror its own extrapolation: `Constant`, `Linear` and `Extension` all integrate the boundary value, `_first(A.u) * (first(A.t) - t)` / `_last(A.u) * (t - last(A.t))`. `Periodic` and `Reflective` were already correct, so the shared handling is factored out into `_extrapolate_integral_other_left`/`_right` (mirroring the existing `_extrapolate_other` in `interpolation_methods.jl`) rather than duplicated.

Rebased onto #573, so this uses the `_first`/`_last` accessors and is correct for matrix `u` as well; the extrapolated integral stays within #573's allocation budget (measured 3–4 result arrays against a budget of 6).

## Verification

Reproduction from the issue, before and after. `quadgk` integrates `A` itself, so the reference column is what the interpolation object actually evaluates to.

```julia
using DataInterpolations, QuadGK

u = [1.0, 2.0, 5.0]
t = [1.0, 2.0, 3.0]

for dir in (:left, :right),
    extrapolation in (
        ExtrapolationType.Constant, ExtrapolationType.Linear, ExtrapolationType.Extension,
    )

    A = ConstantInterpolation(u, t; extrapolation, dir)
    for (side, t1, t2) in (("left", -1.0, 1.0), ("right", 3.0, 5.0))
        got = DataInterpolations.integral(A, t1, t2)
        want = quadgk(A, t1, t2; atol = 1.0e-12, rtol = 1.0e-12)[1]
        println(rpad("dir=$dir $extrapolation $side", 40), rpad(got, 6), " vs ", want)
    end
end
```

Before (master, `c37fceb`):

```
dir=left Constant left                  2.0    vs 2.0
dir=left Constant right                 10.0   vs 10.0
dir=left Linear left                    NaN    vs 2.0
dir=left Linear right                   NaN    vs 10.0
dir=left Extension left                 2.0    vs 2.0
dir=left Extension right                4.0    vs 10.0
dir=right Constant left                 2.0    vs 2.0
dir=right Constant right                10.0   vs 10.0
dir=right Linear left                   NaN    vs 2.0
dir=right Linear right                  NaN    vs 10.0
dir=right Extension left                4.0    vs 2.0
dir=right Extension right               10.0   vs 10.0
```

After:

```
dir=left Constant left                  2.0    vs 2.0
dir=left Constant right                 10.0   vs 10.0
dir=left Linear left                    2.0    vs 2.0
dir=left Linear right                   10.0   vs 10.0
dir=left Extension left                 2.0    vs 2.0
dir=left Extension right                10.0   vs 10.0
dir=right Constant left                 2.0    vs 2.0
dir=right Constant right                10.0   vs 10.0
dir=right Linear left                   2.0    vs 2.0
dir=right Linear right                  10.0   vs 10.0
dir=right Extension left                2.0    vs 2.0
dir=right Extension right               10.0   vs 10.0
```

## Tests

Folded into the existing `@testset "Constant Interpolation"` in `test/extrapolation_tests.jl`: `integral` is checked against `quadgk` for all five extrapolation types × both `dir` settings × three intervals (left of the data, right of the data, spanning the whole range), for both vector and matrix `u` — 60 new tests. Every `Linear`/`Extension` case among them fails without the source change.

Local runs on Julia 1.12.4, rebased onto `ae50f12`:

```
$ GROUP=Methods julia --project -e 'using Pkg; Pkg.test()'
Test Summary:               |  Pass  Total     Time
Methods/derivative_tests.jl | 34479  34479  6m02.4s
Test Summary:                     | Pass  Total   Time
Methods/integral_inverse_tests.jl |  317    317  33.5s
Test Summary:             | Pass  Total   Time
Methods/integral_tests.jl | 8227   8227  48.1s
Test Summary:           | Pass  Total  Time
Methods/online_tests.jl |   30     30  2.2s
Test Summary:                  | Pass  Total   Time
Methods/thread_safety_tests.jl |   21     21  26.7s
     Testing DataInterpolations tests passed
```

`GROUP=Core` goes from `202 passed, 1 errored` to `262 passed, 1 errored`. The one error is **not from this PR** — `@testset "Matrix u extrapolation allocations"` errors identically on a clean `ae50f12` worktree, because `@allocated(uᵢ .+ 1.0)` in `result_bytes` throws `UndefVarError: .+` on Julia 1.12. Filed separately as https://github.com/SciML/DataInterpolations.jl/issues/575. Before the rebase, on `c37fceb` where that test did not yet exist, `GROUP=Core` was fully green with these tests included (`Core/extrapolation_tests.jl | 136 136`).

Runic-formatted.

## Out of scope, noticed while fixing this

`derivative` has the same `Linear` bug: `DataInterpolations.derivative(A, first(t) - 1.5)` for a `ConstantInterpolation` with `ExtrapolationType.Linear` returns `NaN`, while `ForwardDiff.derivative(A, ...)` returns `0.0` — the extrapolated function is flat, so `0.0` is right. This is why `test_extrapolation(ConstantInterpolation, u, t)` still cannot be enabled wholesale; the integral half of it now passes. Happy to do it as a follow-up.

(The `SmoothedConstantInterpolation` dead-code branch I originally noted here was already fixed by #573.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DzymrVDpsrtEd3rxizPVuh
