### PR TITLE
Fix `@allocated` on a dot-call throwing on Julia 1.12.0-1.12.4

### DIFF
--- a/test/extrapolation_tests.jl
+++ b/test/extrapolation_tests.jl
@@ -320,10 +320,12 @@ end
 # The number of allocations one array costs is a Julia version detail, so the
 # budgets below are expressed in bytes relative to one result array. The counting
 # sits behind a function barrier to keep the test scope's boxing out of it.
+# `broadcast` rather than `.+`: `@allocated` on a dot-call throws `UndefVarError: .+`
+# on Julia 1.12.0-1.12.4.
 function result_bytes(u)
     uᵢ = @view u[:, 1]
-    uᵢ .+ 1.0
-    return @allocated(uᵢ .+ 1.0)
+    broadcast(+, uᵢ, 1.0)
+    return @allocated(broadcast(+, uᵢ, 1.0))
 end
 
 function extrapolation_allocations(A, t_eval)


### PR DESCRIPTION
Fixes https://github.com/SciML/DataInterpolations.jl/issues/575.

> **Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Problem

`result_bytes` in `test/extrapolation_tests.jl` (added in https://github.com/SciML/DataInterpolations.jl/pull/573) measures `@allocated(uᵢ .+ 1.0)`. On some Julia 1.12 patch releases that throws `UndefVarError: \`.+\``, erroring the `"Matrix u extrapolation allocations"` testset and failing `GROUP=Core`.

## Fix

Use an explicit `broadcast(+, uᵢ, 1.0)` — same measurement, no dot-call inside the macro.

## Affected versions

Ran the minimal repro (`result_bytes` alone, no package) across every installed version:

| Julia | dot-call form | `broadcast` form |
|---|---|---|
| 1.10.11 | 80 | 80 |
| 1.11.9 | 80 | 80 |
| **1.12.0** | **`UndefVarError(:.+, …)`** | 80 |
| 1.12.5 | 80 | 80 |
| 1.12.6 | 80 | 80 |
| 1.13.0-rc1 | 80 | 80 |

So the underlying Julia bug exists in the 1.12.0–1.12.4 window (the issue reporter hit it on 1.12.4) and was fixed upstream by 1.12.5. It is invisible to CI because `1` currently resolves to 1.12.6. The fix is still worth having: it keeps the suite runnable for anyone on a 1.12.0–1.12.4 install, and the `broadcast` form is not sensitive to how `@allocated` handles dot-syntax on any future version.

## Verification

`GROUP=Core` on Julia 1.12.0, **before** this change:

```
Matrix u extrapolation allocations: Error During Test at .../test/extrapolation_tests.jl:342
  Got exception outside of a @test
  UndefVarError: `.+` not defined in `Main.var"##Core/extrapolation_tests.jl#277"`
  ...
    [2] result_bytes(u::Matrix{Float64})
ERROR: LoadError: Some tests did not pass: 202 passed, 0 failed, 1 errored, 0 broken.
```

`GROUP=Core` on Julia 1.12.0, **after**:

```
Test Summary:               | Pass  Total     Time
Core/extrapolation_tests.jl |  256    256  1m30.9s
Test Summary:     | Pass  Total   Time
Core/interface.jl |   28     28  30.3s
Test Summary:               |  Pass  Broken  Total     Time
Core/interpolation_tests.jl | 17414       5  17419  4m23.5s
Test Summary:           | Pass  Total   Time
Core/parameter_tests.jl |   20     20  45.5s
     Testing DataInterpolations tests passed
```

Runic check on the modified file is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5pyRS7V5oGLMhb8xw1ECR