### PR TITLE
Report ill-conditioned B-spline collocation systems

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -28,7 +28,7 @@ corresponding to `(u,t)` pairs.
   - `BSplineInterpolation(u,t,d,knotVec)` - An interpolation B-spline. This is a B-spline that hits each of the data points. The argument choices are:
     
       + `d` - degree of B-spline
-      + `knotVec` - Symbol to Knot Vector, `knotVec = :Uniform` for uniform knot vector, `knotVec = :Average` for average spaced knot vector.
+      + `knotVec` - Symbol to Knot Vector, `knotVec = :Uniform` for uniform knot vector, `knotVec = :Average` for average spaced knot vector. Use `:Average` for interpolation: `:Uniform` spaces the interior knots inconsistently with the data sites, which makes the collocation system exponentially ill-conditioned in the number of data points for `d >= 3`, and constructing one warns.
   - `BSplineApprox(u,t,d,h,knotVec)` - A regression B-spline which smooths the fitting curve. The argument choices are the same as the `BSplineInterpolation`, with the additional parameter `h<length(t)` which is the number of control points to use, with smaller `h` indicating more smoothing.
   - `CubicHermiteSpline(du, u, t)` - A third order Hermite interpolation, which matches the values and first (`du`) order derivatives in the data points exactly.
   - `PCHIPInterpolation(u, t)` - a type of `CubicHermiteSpline` where the derivative values `du` are derived from the input data in such a way that the interpolation never overshoots the data.

--- a/ext/DataInterpolationsMooncakeExt.jl
+++ b/ext/DataInterpolationsMooncakeExt.jl
@@ -1,7 +1,7 @@
 module DataInterpolationsMooncakeExt
 
 using DataInterpolations: _interpolate, munge_data, AbstractInterpolation,
-    LinearInterpolation, QuadraticInterpolation
+    LinearInterpolation, QuadraticInterpolation, warn_if_ill_conditioned
 using ChainRulesCore: ChainRulesCore
 using FindFirstFunctions: FindFirstFunctions
 using Mooncake: Mooncake, @from_chainrules, @zero_adjoint, MinimalCtx, DefaultCtx
@@ -62,5 +62,9 @@ end
 @zero_adjoint DefaultCtx Tuple{typeof(FindFirstFunctions.searchsorted_first), FindFirstFunctions.Auto, AbstractVector, Any, Integer}
 @zero_adjoint DefaultCtx Tuple{typeof(FindFirstFunctions.searchsorted_last), FindFirstFunctions.Auto, AbstractVector, Any}
 @zero_adjoint DefaultCtx Tuple{typeof(FindFirstFunctions.searchsorted_first), FindFirstFunctions.Auto, AbstractVector, Any}
+
+# Diagnostic only: returns `nothing` and just emits a warning. `@warn` expands to a
+# try/catch, which Mooncake cannot differentiate in reverse mode.
+@zero_adjoint DefaultCtx Tuple{typeof(warn_if_ill_conditioned), Any, Any, Any, Any, Any}
 
 end

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -28,7 +28,7 @@ true
 """
 abstract type AbstractInterpolation{T} end
 
-using LinearAlgebra: LinearAlgebra, Tridiagonal, dot, norm, normalize!
+using LinearAlgebra: LinearAlgebra, Tridiagonal, dot, lu, norm, normalize!, opnorm
 using RecipesBase: RecipesBase, @recipe, @series
 using PrettyTables: PrettyTables, pretty_table
 using ForwardDiff: ForwardDiff

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -936,6 +936,10 @@ Extrapolation is a constant polynomial of the end points on each side.
   - `t`: time points.
   - `d`: degree of the piecewise polynomial.
   - `knotVecType`: symbol to knot vector, `:Uniform` for uniform knot vector, `:Average` for average spaced knot vector.
+    `:Average` is the appropriate choice for interpolation. `:Uniform` spaces the interior knots inconsistently with
+    the data sites, which makes the collocation system exponentially ill-conditioned in the number of points for
+    `d >= 3`; constructing such an interpolation warns, and the result may deviate from the data by orders of
+    magnitude between the data points even though it still passes through them.
 
 ## Keyword Arguments
 
@@ -1022,7 +1026,10 @@ function BSplineInterpolation(
         k[n + i] = t[end]
     end
     if knotVecType == :Uniform
-        # Uniformly spaced interior knots
+        # Uniformly spaced interior knots. Spacing is `1/(n - d)` against a data site
+        # spacing of `1/(n - 1)`, so the collocation pairing drifts by up to `(d - 1)/2`
+        # knot spans; past half a span the system is exponentially ill-conditioned in
+        # `n`, which rules this choice out for interpolation at `d >= 3` (#567).
         for i in (d + 2):n
             k[i] = t[1] + (i - d - 1) // (n - d) * (t[end] - t[1])
         end
@@ -1037,7 +1044,8 @@ function BSplineInterpolation(
     # control points
     sc = zeros(eltype(t), n, n)
     spline_coefficients!(sc, d, k, t)
-    c = vec(sc \ u[:, :])
+    F = bspline_collocation_factorization(sc, n, d, knotVecType)
+    c = vec(F \ u[:, :])
     sc = zeros(eltype(t), n)
     return BSplineInterpolation(
         u, t, d, k, c, sc, knotVecType,
@@ -1069,7 +1077,10 @@ function BSplineInterpolation(
         k[n + i] = t[end]
     end
     if knotVecType == :Uniform
-        # Uniformly spaced interior knots
+        # Uniformly spaced interior knots. Spacing is `1/(n - d)` against a data site
+        # spacing of `1/(n - 1)`, so the collocation pairing drifts by up to `(d - 1)/2`
+        # knot spans; past half a span the system is exponentially ill-conditioned in
+        # `n`, which rules this choice out for interpolation at `d >= 3` (#567).
         for i in (d + 2):n
             k[i] = t[1] + (i - d - 1) // (n - d) * (t[end] - t[1])
         end
@@ -1083,7 +1094,8 @@ function BSplineInterpolation(
     # control points
     sc = zeros(eltype(t), n, n)
     spline_coefficients!(sc, d, k, t)
-    c = (sc \ reshape(u, prod(size(u)[1:(end - 1)]), :)')'
+    F = bspline_collocation_factorization(sc, n, d, knotVecType)
+    c = (F \ reshape(u, prod(size(u)[1:(end - 1)]), :)')'
     c = reshape(c, size(u)...)
     sc = zeros(eltype(t), n)
     return BSplineInterpolation(

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -154,6 +154,64 @@ end
     return N, i - d - 1, d + 1
 end
 
+# Hager's estimate of `‖inv(A)‖₁` from an existing factorization: a handful of solves
+# against `F` and `F'`, so O(n²) on top of the factorization rather than the O(n³) an
+# explicit inverse would cost. This is what LAPACK's `gecon` does internally.
+function norm_inv_1_estimate(F, n)
+    x = fill(one(eltype(F)) / n, n)
+    est = zero(real(eltype(F)))
+    for _ in 1:5
+        y = F \ x
+        est = norm(y, 1)
+        z = F' \ map(yᵢ -> yᵢ < zero(yᵢ) ? -one(yᵢ) : one(yᵢ), y)
+        j = argmax(abs.(z))
+        abs(z[j]) <= dot(z, x) && break
+        fill!(x, zero(eltype(x)))
+        x[j] = one(eltype(x))
+    end
+    return est
+end
+
+# A `:Uniform` knot vector spaces the interior knots by `1/(n - d)` while the data
+# sites are spaced `1/(n - 1)`, so the collocation points drift away from the Greville
+# abscissae of the basis functions they are paired with — by up to `(d - 1)/2` knot
+# spans, independent of `n`. Past half a span the collocation system's condition number
+# grows exponentially in `n`, and the interpolant diverges between the data points
+# while still passing through them, so nothing about the fit looks wrong (#567).
+# `:Average` knots are the standard pairing for interpolation and stay well conditioned.
+function bspline_collocation_factorization(sc, n, d, knotVecType)
+    F = lu(sc; check = false)
+    LinearAlgebra.issuccess(F) || error(
+        "BSplineInterpolation: the collocation system for degree $d with " *
+            "`knotVecType = :$knotVecType` and $n points is numerically singular." *
+            ill_conditioned_advice(d, knotVecType)
+    )
+    warn_if_ill_conditioned(F, sc, n, d, knotVecType)
+    return F
+end
+
+# Only degree 3 and up: the drift peaks at `(d - 1)/2` knot spans, so it first crosses
+# the half-span stability threshold at `d = 3`. Degrees 1 and 2 are sound with
+# `:Uniform` knots, and a failure there is caused by something else — duplicate data
+# sites, say — which this advice would misattribute.
+function ill_conditioned_advice(d, knotVecType)
+    (knotVecType == :Uniform && d >= 3) || return ""
+    return " A `:Uniform` knot vector is unsuitable for interpolation at degree $d; " *
+        "use `knotVecType = :Average` instead."
+end
+
+function warn_if_ill_conditioned(F, sc, n, d, knotVecType)
+    κ = opnorm(sc, 1) * norm_inv_1_estimate(F, n)
+    κ <= 1 / sqrt(eps(float(real(eltype(sc))))) && return nothing
+    @warn "BSplineInterpolation: the collocation system for degree $d with " *
+        "`knotVecType = :$knotVecType` and $n points is ill-conditioned (estimated " *
+        "1-norm condition number $(round(κ, sigdigits = 3))). The interpolant still " *
+        "passes through the data but may deviate from it by orders of magnitude in " *
+        "between, most visibly near the ends of the domain." *
+        ill_conditioned_advice(d, knotVecType)
+    return nothing
+end
+
 function quadratic_spline_params(t::AbstractVector, sc::AbstractVector)
     # Duplicate time points make the collocation system singular
     if any(i -> t[i] == t[i + 1], 1:(length(t) - 1))

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -1414,6 +1414,58 @@ end
         end
     end
 
+    # `:Uniform` knots space the interior knots by `1/(n - d)` against a data site
+    # spacing of `1/(n - 1)`, so the collocation system becomes exponentially
+    # ill-conditioned in `n` for degree 3 and up. The fit still passes through the data,
+    # so the only signal the caller gets is the warning (#567).
+    @testset "Ill-conditioned collocation systems are reported" begin
+        f(x) = sin(x)
+        build(n, d, knotVecType) = BSplineInterpolation(
+            f.(range(0, 2π, length = n)), collect(range(0, 2π, length = n)),
+            d, knotVecType
+        )
+
+        @test_logs (:warn, r"ill-conditioned") match_mode = :any build(160, 3, :Uniform)
+        @test_logs (:warn, r"ill-conditioned") match_mode = :any build(320, 3, :Uniform)
+        @test_logs (:warn, r"ill-conditioned") match_mode = :any build(80, 5, :Uniform)
+        # The message has to point somewhere useful.
+        @test_logs (:warn, r"knotVecType = :Average") match_mode = :any build(160, 3, :Uniform)
+
+        # `:Average` knots are well conditioned at any degree or size, and small
+        # problems with `:Uniform` knots are still fine, so neither may warn.
+        @test_nowarn build(160, 3, :Average)
+        @test_nowarn build(640, 5, :Average)
+        @test_nowarn build(20, 3, :Uniform)
+        @test_nowarn build(6, 3, :Uniform)
+        # Degrees 1 and 2 never drift past half a knot span, so they stay sound.
+        @test_nowarn build(320, 1, :Uniform)
+        @test_nowarn build(320, 2, :Uniform)
+
+        # Whether the factorization hits an exact zero pivot at large `n` is
+        # BLAS-dependent, so drive the singular branch with duplicate data sites, which
+        # give the collocation matrix two identical rows.
+        u_dup = [1.0, 2.0, 2.0, 3.0, 5.0, 8.0]
+        t_dup = [0.0, 1.0, 1.0, 2.0, 3.0, 4.0]
+        @test_throws "numerically singular" BSplineInterpolation(u_dup, t_dup, 2, :Average)
+        # Degree 2 is not a knot-vector problem, so it must not be blamed on one.
+        err = try
+            BSplineInterpolation(u_dup, t_dup, 2, :Uniform)
+        catch e
+            sprint(showerror, e)
+        end
+        @test !occursin("knotVecType = :Average", err)
+
+        # `:Average` knots keep the interpolant convergent at the requested order over
+        # the range where `:Uniform` diverges, which is the property being protected.
+        xq = range(0, 2π, length = 2001)
+        maxerr(A) = maximum(abs(A(x) - f(x)) for x in xq)
+        errs = map((160, 320)) do n
+            maxerr(build(n, 3, :Average))
+        end
+        @test log2(errs[1] / errs[2]) > 3.5
+        @test errs[2] < 1.0e-9
+    end
+
     @testset "BSplineApprox" begin
         test_interpolation_type(BSplineApprox)
         t = [0, 62.25, 109.66, 162.66, 205.8, 252.3]

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -16,7 +16,7 @@ using ChainRulesCore, Makie, Mooncake, Optim, SparseConnectivityTracer, Symbolic
 const DATAINTERPOLATIONS_INTERNALS = (
     :AbstractInterpolation, :CurvefitCache, :DerivativeNotFoundError,
     :ExtrapolationError, :IntegralNotFoundError, :_interpolate, :derivative, :get_idx,
-    :get_show, :integral, :munge_data, :to_plottable,
+    :get_show, :integral, :munge_data, :to_plottable, :warn_if_ill_conditioned,
 )
 
 run_qa(


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

Fixes the remaining half of #567. Rewritten against master after #511 landed; supersedes the closed #569, which was stacked on the now-closed #568 and no longer applied.

## Status of #567 after #511

#511 removed the intermediate `p ∈ [0, 1]` parameterization, which fixed the **second** half of the issue — `:Average` knots now converge at the requested order instead of sticking at 2:

| n | d=3 | ratio | d=5 | ratio |
|---|---|---|---|---|
| 80 | 1.04e-7 | 30.2 | 5.00e-10 | 138.4 |
| 160 | 6.35e-9 | 16.4 | 3.75e-12 | 133.3 |
| 320 | 3.92e-10 | 16.2 | 2.86e-14 | 130.8 |

The **first** half was never a parameterization bug, so #511 left it untouched. On master (251b132), `f = sin` on `[0, 2π]`, max error over 2001 points:

| n | d=3 (issue → master) | d=5 (issue → master) |
|---|---|---|
| 160 | 4.79e-6 → 6.87e-6 | 6.81e18 → 3.56e18 |
| 320 | 8.49e5 → 2.68e5 | 2.69e55 → 2.41e55 |
| 640 | 5.81e27 → 7.59e27 | `SingularException` → 2.60e126 |

The one thing #511 did change is that the `SingularException` no longer fires, so the failure is now entirely silent.

## Root cause

The interior knots are spaced `1/(n - d)` while the data sites are spaced `1/(n - 1)`. Collocation row `i` is paired with basis function `i`, whose natural centre is its Greville abscissa, so the two grids drift apart — by up to `(d - 1)/2` knot spans across the domain, **independent of `n`**. Half a knot span is the stability threshold, which is why the onset is degree-dependent: `d = 1` is exact, `d = 2` is marginal, `d ≥ 3` is broken.

Condition numbers of the collocation matrix, built through the current code path:

```
              n=20      n=80      n=160     n=320
Uniform d=3   37.16     3.079e5   8.667e10  7.468e21
Uniform d=5   2637.0    5.248e16  5.809e34  7.792e70
Average d=3   5.476     5.476     5.476     5.476
Average d=5   23.98     23.98     23.98     23.98
```

This is *not* fixable by adjusting the knot spacing: the spline space dimension forces exactly `n - d - 1` interior knots, so `1/(n - d)` is the only uniform spacing available. `:Uniform` knots are structurally the wrong choice for collocation, which is why de Boor's averaging rule (`:Average`) exists. The existing source comment said `:Uniform` knots were risky only when combined with the chord-length method — that parameterization is gone, and the comment understated the problem regardless.

## The change

Since the configuration cannot be repaired and erroring outright would break code that works at small `n`, this reports rather than silently returning garbage:

1. **Warn on an ill-conditioned collocation system.** Estimated with Hager's 1-norm algorithm on the factorization the solve needs anyway — a handful of solves against `F` and `F'`, so O(n²) on top of an O(n³) factorization. No explicit inverse, no reliance on `LAPACK.gecon!` internals. The estimate is exact to every printed digit against `cond(sc, 1)` on these matrices (both columns above are estimate/true, and they agree).

   Threshold is `1/sqrt(eps(T))`, i.e. half the significant digits lost. Separation is clean: `:Average` sits at 5.5/24 flat in `n`, so it never warns, and small `:Uniform` problems stay quiet. Warning onset matches the issue's reported onset exactly — `d = 3` from `n = 160`, `d = 5` from `n = 80`.

2. **Replace the bare `SingularException` with an explanatory error** naming the configuration.

3. **Correct the misleading comment**, the `knotVecType` docstring, and `docs/src/index.md`.

The message is actionable rather than diagnostic:

> BSplineInterpolation: the collocation system for degree 3 with `knotVecType = :Uniform` and 160 points is ill-conditioned (estimated 1-norm condition number 8.67e10). The interpolant still passes through the data but may deviate from it by orders of magnitude in between, most visibly near the ends of the domain. A `:Uniform` knot vector is unsuitable for interpolation at degree 3; use `knotVecType = :Average` instead.

The knot-vector advice is gated on `d >= 3`. Degrees 1 and 2 are sound with `:Uniform` knots, so a failure there has some other cause — duplicate data sites, say — that this advice would misattribute.

Warning rather than erroring keeps this non-breaking. If you would rather `:Uniform` be rejected outright for `d >= 3`, that is a one-line change from here; I did not assume it, since it would break working small-`n` code.

## Cost

The estimate is O(n²) against an O(n³) factorization, so its share shrinks with `n`. Measured against `lu` on the same matrices, single-threaded BLAS:

| n | `lu` | estimate | overhead |
|---:|---:|---:|---:|
| 500 | 4.83 ms | 0.24 ms | 5.1% |
| 2000 | 189.21 ms | 5.49 ms | 2.9% |

## Scope

`BSplineApprox` is **not** affected and is left alone — I checked. Its least-squares fit (`h < n` control points) has no exact collocation pairing to break, and it goes through a separate solve that this PR does not touch.

## Tests

New `@testset "Ill-conditioned collocation systems are reported"`:

- warns for the configurations from the issue (`:Uniform` at `d = 3`, `n = 160` and `320`; `d = 5`, `n = 80`);
- the message points at `:Average`;
- `@test_nowarn` for `:Average` at any degree/size, for small `:Uniform` problems that are still fine, and for `:Uniform` at degrees 1 and 2 at large `n`;
- the singular case errors with the explanatory message instead of `SingularException`, driven by duplicate data sites rather than large `n` (whether the factorization hits an exact zero pivot at large `n` is BLAS-dependent);
- degree 2 singularity is *not* blamed on the knot vector;
- `:Average` still converges at order > 3.5 over the range where `:Uniform` diverges, which is the property being protected.

One QA consequence: `warn_if_ill_conditioned` is imported by the Mooncake extension, and an extension's `Base.moduleroot` is itself rather than the package it extends, so ExplicitImports reports it. It is a genuinely private implementation detail — promoting it to public API would be wrong — so it joins the existing `DATAINTERPOLATIONS_INTERNALS` allowlist that already exists for exactly this case.

The `@zero_adjoint` is needed because `@warn` expands to a try/catch that Mooncake cannot differentiate in reverse mode; it returns `nothing` and is purely diagnostic, matching the pattern already used there for `searchsorted_*`.

## Test status

Run locally on Julia 1.11.9. `Core`, `Methods`, `Misc`, `Extensions` all pass:

```
Core/interpolation_tests.jl   | 17428 passed, 5 broken
Core/extrapolation_tests.jl   |   316 passed
Core/interface.jl             |    28 passed
Core/parameter_tests.jl       |    20 passed
Methods/derivative_tests.jl   | 34479 passed
Methods/integral_tests.jl     |  8227 passed
Methods/integral_inverse_tests.jl |  317 passed
Methods/online_tests.jl       |    30 passed
Methods/thread_safety_tests.jl|    21 passed
Misc/public_api.jl, show.jl   |    18 passed
Extensions/mooncake_tests.jl  |   604 passed
Extensions/sparseconnectivitytracer_tests.jl | 600 passed
Extensions/zygote_tests.jl    | 11974 passed
```

`QA` has one failure that **reproduces identically on an unmodified master checkout** — I ran both rather than assuming: `all_qualified_accesses_are_public` fails on `require_one_based_indexing`, which is not public in `Base` but is imported at `src/interpolation_utils.jl`. Branch and master are both `19 passed, 0 failed, 1 errored`. Not touched by this PR; happy to open a separate issue.

Runic clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVMaSPYYjJQu9mPkWnRopy
