### PR TITLE
Set DataInterpolations version to 9.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.2.0"
+version = "9.2.1"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

Correct the package version declarations to the first sequential patch or minor release after General's latest non-yanked versions. The default branch contains source changes, but this PR is limited to release metadata and internal compat needed by the sequential versions.

| Package | General | Branch before | Proposed | Bump |
|---|---:|---:|---:|---|
| DataInterpolations | 9.2.0 | 9.2.0 | 9.2.1 | patch |

## Verification

- `GROUP=QA /home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:     | Pass  Total     Time / QA/alloc_tests.jl |   16     16  1m33.2s / Test Summary: | Pass  Total     Time / QA/qa.jl      |   20     20  1m51.8s / Testing DataInterpolations tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --project=. -e 'using Pkg; Pkg.test()'` — passed. `Test Summary:      | Pass  Total  Time / Misc/public_api.jl |    8      8  0.4s / Test Summary: | Pass  Total   Time / Misc/show.jl  |   10     10  22.4s / Testing DataInterpolations tests passed`
- `/home/crackauc/.juliaup/bin/julia +release --startup-file=no -m Runic --check .` — passed.
- `typos --force-exclude Project.toml` — passed.
- `git diff --check` — passed.

The docs build was not run because this diff changes no docstrings, documentation, or public API. GPU and downstream jobs were not run locally.

## Registration

After this PR is merged, register each package separately from a commit on the default branch:

- DataInterpolations: `@JuliaRegistrator register`