### PR TITLE
Avoid KIND_LINEAR_SCAN on short non-uniform interpolations (#580)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 
   - Every interpolation constructor accepts a `search_properties::Union{Nothing, FindFirstFunctions.SearchProperties}` keyword. The default `nothing` probes `t` at construction; passing a pre-built `SearchProperties` skips the probe (useful when constructing many interpolations over the same knot vector).
 
-  - Knot search is dispatched through `FindFirstFunctions.Auto(t)` resolved at construction: uniformly-spaced knots (any `AbstractRange`, or vectors detected as exactly uniform) use a closed-form O(1) lookup; short non-uniform knot vectors use a linear scan; everything else keeps the previous bracketed gallop.
+  - Knot search is dispatched through `FindFirstFunctions.Auto(t)` resolved at construction: uniformly-spaced knots (any `AbstractRange`, or vectors detected as exactly uniform) use a closed-form O(1) lookup; non-uniform knot vectors use the previous bracketed gallop. `KIND_LINEAR_SCAN` (Auto's pick for `length(t) ≤ 16`) is remapped to `KIND_BRACKET_GALLOP` because the linear-scan kernel crashes on Windows (`RtlVirtualUnwind2`) when evaluated from an OrdinaryDiffEq Dual RHS ([#580](https://github.com/SciML/DataInterpolations.jl/issues/580)).
 
   - `LinearInterpolation` with uniformly-spaced knots and floating-point values takes a statically-dispatched fast path (closed-form index + lerp, verified against the live knots) — 5-10x faster per query on uniform grids.
 

--- a/src/interpolation_utils.jl
+++ b/src/interpolation_utils.jl
@@ -345,9 +345,17 @@ end
 # Resolve the search `StrategyKind` once at construction; stored as the
 # non-parametric `kind::StrategyKind` cache field. The props-aware form
 # reuses an already-computed `SearchProperties` instead of re-probing `t`.
-@inline _resolve_strategy_kind(t::AbstractVector) = FindFirstFunctions.Auto(t).kind
-@inline _resolve_strategy_kind(t::AbstractVector, props::FindFirstFunctions.SearchProperties) =
-    FindFirstFunctions.Auto(t, props).kind
+# LINEAR_SCAN (Auto's pick for non-uniform length(t) ≤ 16) AVs on Windows
+# inside RtlVirtualUnwind2 from Dual ODE RHS calls; BracketGallop does not.
+@inline function _resolve_strategy_kind(
+        t::AbstractVector, props::FindFirstFunctions.SearchProperties
+    )
+    kind = FindFirstFunctions.Auto(t, props).kind
+    return kind === FindFirstFunctions.KIND_LINEAR_SCAN ?
+        FindFirstFunctions.KIND_BRACKET_GALLOP : kind
+end
+@inline _resolve_strategy_kind(t::AbstractVector) =
+    _resolve_strategy_kind(t, FindFirstFunctions.SearchProperties(t))
 
 function get_idx(
         A::AbstractInterpolation, t, iguess::Integer; lb = 1,

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -436,6 +436,22 @@ end
     end
 end
 
+@testset "Short non-uniform knots do not use LINEAR_SCAN" begin
+    t = [0.0, 0.3, 1.1, 2.0, 3.5, 5.0, 6.2, 8.0]
+    u = [1.0, 1.2, 2.0, 2.5, 3.1, 3.0, 4.2, 5.0]
+    for A in (
+            LinearInterpolation(u, t),
+            ConstantInterpolation(u, t),
+            PCHIPInterpolation(u, t),
+        )
+        @test A.kind === FindFirstFunctions.KIND_BRACKET_GALLOP
+        @test A(3.5) isa Number
+    end
+    Ainv = DataInterpolations.invert_integral(LinearInterpolation(u .+ 1, t))
+    @test Ainv.kind === FindFirstFunctions.KIND_BRACKET_GALLOP
+    @test Ainv(Ainv.t[end] / 2) isa Number
+end
+
 @testset "Quadratic Interpolation" begin
     test_interpolation_type(QuadraticInterpolation)
 


### PR DESCRIPTION
Please ignore this PR until it is reviewed by @ChrisRackauckas.

## What changed and why

`FindFirstFunctions.Auto` picks `KIND_LINEAR_SCAN` for non-uniform knots with `length(t) ≤ 16`. That path is the one isolated as the Windows `EXCEPTION_ACCESS_VIOLATION` in `ntdll!RtlVirtualUnwind2` when interpolations are evaluated from an OrdinaryDiffEq Dual RHS ([#580](https://github.com/SciML/DataInterpolations.jl/issues/580)). `KIND_BRACKET_GALLOP` does not reproduce.

`_resolve_strategy_kind` now remaps `KIND_LINEAR_SCAN` → `KIND_BRACKET_GALLOP`. That is the v8 search default for these interpolations. Uniform knots still use `KIND_UNIFORM_STEP`.

This is a workaround, not a root-cause fix of the Windows unwind crash. The linear-scan kernel itself matches `Base.searchsortedlast` (500-case fuzz, 0 mismatches) and is in-bounds under `--check-bounds=yes`. The crash looks like a codegen / unwind-info Heisenbug (`@profview` makes it more likely; prints hide it). We do not have a Windows box here, so we ship the path SouthEndMusic already confirmed is safe.

Standalone MWE (Ribasim-shaped: 40 basins, 8-knot profiles, `invert_integral`, PCHIP Q-H, Rosenbrock + ForwardDiff): https://github.com/SciML/DataInterpolations.jl/issues/580#issuecomment-5273108807

## Verification

Discriminating test (short non-uniform `Linear` / `Constant` / `PCHIP` / `invert_integral` must be `KIND_BRACKET_GALLOP`):

- **Before** (master, no remap): `KIND_LINEAR_SCAN === KIND_BRACKET_GALLOP` fails 4 times.
- **After**: 8/8 pass; kinds are `KIND_BRACKET_GALLOP`. Range knots still resolve to `KIND_UNIFORM_STEP`.

Local (Julia 1.12.6):

```
GROUP=Core  Pkg.test()  → interpolation_tests 17436 pass, 5 pre-existing broken; Core all green
GROUP=QA    Pkg.test()  → alloc_tests 16 pass; qa.jl 20 pass
runic -c on the touched .jl files: clean
typos on the diff: clean
```

## What I did not verify

- The Windows AV itself. This machine is Linux. I cannot show the crash disappearing.
- `GROUP=Methods`, `GROUP=Extensions`, GPU, downstream (Ribasim). Methods was started locally; say so if it is still running when this is filed.
- Whether `@noinline` on the FFF linear-scan kernel would also stop the AV while keeping the algorithm. That is a plausible follow-up in FindFirstFunctions once someone can test on Windows.

## Judgment call

Remapping rather than trying to keep LINEAR_SCAN via `@noinline`. Evidence for the remap: SouthEndMusic reproduced with LINEAR_SCAN and not with BRACKET_GALLOP. Evidence for `@noinline` as a complete fix: none on this machine.