### PR TITLE
docs: audit public and developer interpolation APIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.2.1"
+version = "9.3.0"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,7 @@ makedocs(
         "Interpolation methods" => "methods.md",
         "Extrapolation methods" => "extrapolation_methods.md",
         "Interface" => "interface.md",
+        "Abstract interpolation interface" => "abstract_interpolation.md",
         "Using with Symbolics/ModelingToolkit" => "symbolics.md",
         "Manual" => "manual.md",
         "Smooth arc length interpolation" => "arclength_interpolation.md",

--- a/docs/src/abstract_interpolation.md
+++ b/docs/src/abstract_interpolation.md
@@ -5,6 +5,10 @@ public evaluation, differentiation, and integration functions are generic over t
 so downstream code should use those functions rather than dispatching on a concrete
 interpolation implementation.
 
+```@docs
+DataInterpolations.AbstractInterpolation
+```
+
 ## Required data
 
 A concrete subtype must provide the following fields:
@@ -16,9 +20,17 @@ A concrete subtype must provide the following fields:
 - `extrapolation_left` and `extrapolation_right`: values from
   [`ExtrapolationType`](@ref) controlling out-of-range evaluation.
 
-The generic integration method also uses `I` when it is present. This field stores cumulative
-integrals for a cached implementation. A method without an analytic integral should omit
-`I`; `integral` then reports `IntegralNotFoundError`.
+For the generic integral interface, the subtype also provides:
+
+- `I`: cumulative integrals for the intervals, or an empty cache when
+  `cache_parameters` is `false`. A method without an analytic integral should omit this
+  field; `integral` then reports `IntegralNotFoundError`.
+- `cache_parameters::Bool`: whether the generic integral method reads the cached `I` values.
+- `kind` and `t_props`: interval-search state, normally constructed from
+  `FindFirstFunctions.SearchProperties(t)` and `FindFirstFunctions.Auto(t, t_props)`.
+
+Construct `iguesser` with `FindFirstFunctions.Guesser(t)`. The `t` values must remain ordered,
+and `u` must store one sample per `t` entry along its last dimension.
 
 ## Developer hooks
 
@@ -51,14 +63,23 @@ The following sketch shows the required dispatch. A production implementation sh
 validate its data and provide the fields needed by any optional features it supports.
 
 ```julia
+using FindFirstFunctions
+
 struct MyInterpolation <: DataInterpolations.AbstractInterpolation{Float64}
     u::Vector{Float64}
     t::Vector{Float64}
+    I::Vector{Float64}
     iguesser
     extrapolation_left::DataInterpolations.ExtrapolationType.T
     extrapolation_right::DataInterpolations.ExtrapolationType.T
+    kind::FindFirstFunctions.StrategyKind
+    t_props::FindFirstFunctions.SearchProperties
+    cache_parameters::Bool
 end
 
 DataInterpolations._interpolate(A::MyInterpolation, t::Number, iguess) = 2t
 DataInterpolations._derivative(A::MyInterpolation, t::Number, iguess) = 2.0
+DataInterpolations._integral(
+    A::MyInterpolation, idx::Integer, t1::Number, t2::Number
+) = 2 * (t2 - t1)
 ```

--- a/docs/src/abstract_interpolation.md
+++ b/docs/src/abstract_interpolation.md
@@ -1,0 +1,64 @@
+# Abstract interpolation interface
+
+`AbstractInterpolation` is the extension point for adding a new interpolation method. The
+public evaluation, differentiation, and integration functions are generic over this type,
+so downstream code should use those functions rather than dispatching on a concrete
+interpolation implementation.
+
+## Required data
+
+A concrete subtype must provide the following fields:
+
+- `u`: data values. A vector stores scalar values or one array per sample; an array stores
+  samples along its last dimension.
+- `t`: ordered sample locations with `length(t)` equal to the number of samples in `u`.
+- `iguesser`: reusable interval-search state used by scalar evaluation and differentiation.
+- `extrapolation_left` and `extrapolation_right`: values from
+  [`ExtrapolationType`](@ref) controlling out-of-range evaluation.
+
+The generic integration method also uses `I` when it is present. This field stores cumulative
+integrals for a cached implementation. A method without an analytic integral should omit
+`I`; `integral` then reports `IntegralNotFoundError`.
+
+## Developer hooks
+
+The following methods are the implementation hooks used by the generic interface. They are
+public developer API for packages that add interpolation subtypes, but they are not intended
+to be called by end users.
+
+```@docs
+DataInterpolations._interpolate
+DataInterpolations._derivative
+DataInterpolations._integral
+```
+
+The hooks must satisfy these rules:
+
+- `_interpolate(A, t, iguess)` evaluates one scalar location and returns one data point.
+- `_derivative(A, t, iguess)` returns the first derivative with the same shape as one data
+  point. At a discontinuous knot it returns the left derivative.
+- `_integral(A, idx, t1, t2)` integrates the requested subinterval of
+  `[A.t[idx], A.t[idx + 1]]` and preserves the data-point shape.
+
+The generic forms `A(t)`, `derivative(A, t, order = 1)`, and `integral(A, t)` compose these
+hooks with interval search and extrapolation. A method should therefore be tested through
+those generic functions, including scalar, vectorized, and in-place evaluation where its
+data shape supports them.
+
+## Minimal implementation
+
+The following sketch shows the required dispatch. A production implementation should also
+validate its data and provide the fields needed by any optional features it supports.
+
+```julia
+struct MyInterpolation <: DataInterpolations.AbstractInterpolation{Float64}
+    u::Vector{Float64}
+    t::Vector{Float64}
+    iguesser
+    extrapolation_left::DataInterpolations.ExtrapolationType.T
+    extrapolation_right::DataInterpolations.ExtrapolationType.T
+end
+
+DataInterpolations._interpolate(A::MyInterpolation, t::Number, iguess) = 2t
+DataInterpolations._derivative(A::MyInterpolation, t::Number, iguess) = 2.0
+```

--- a/docs/src/inverting_integrals.md
+++ b/docs/src/inverting_integrals.md
@@ -47,6 +47,7 @@ plot!(ts, A.(ts), fillrange = 0.0, fillalpha = 0.75,
 
 ```@docs
 DataInterpolations.invert_integral
+DataInterpolations.AbstractIntegralInverseInterpolation
 ConstantInterpolationIntInv
 LinearInterpolationIntInv
 ```

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -19,7 +19,6 @@ QuinticHermiteSpline
 # Interface
 
 ```@docs
-DataInterpolations.AbstractInterpolation
 DataInterpolations.derivative
 DataInterpolations.integral
 ```

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -21,8 +21,20 @@ provide `iguesser`, `extrapolation_left`, and `extrapolation_right` fields.
 
 - `u`: data values, with samples indexed along the last dimension.
 - `t`: ordered sample locations corresponding to the samples in `u`.
-- `iguesser`: reusable interval-search state.
+- `iguesser`: reusable interval-search state, normally constructed with
+  `FindFirstFunctions.Guesser(t)`.
 - `extrapolation_left`, `extrapolation_right`: out-of-range evaluation modes.
+
+The generic integral interface additionally requires the following fields:
+
+- `I`: cumulative integrals for the intervals. Use an empty cache when
+  `cache_parameters` is `false`; omit this field when analytic integration is not
+  supported.
+- `cache_parameters::Bool`: whether the generic integral method reads the cached `I`
+  values.
+- `kind` and `t_props`: the interval-search strategy and its properties. Construct these
+  with `FindFirstFunctions.SearchProperties(t)` and
+  `FindFirstFunctions.Auto(t, t_props)`.
 
 The following developer hooks define the behavior of a new interpolation method:
 
@@ -246,7 +258,8 @@ export output_dim, output_size
 @static if VERSION >= v"1.11"
     include_string(
         @__MODULE__,
-        "public AbstractInterpolation, derivative, integral, invert_integral, " *
+        "public AbstractInterpolation, AbstractIntegralInverseInterpolation, " *
+            "derivative, integral, invert_integral, " *
             "_interpolate, _derivative, _integral",
     )
 end

--- a/src/DataInterpolations.jl
+++ b/src/DataInterpolations.jl
@@ -5,14 +5,40 @@ module DataInterpolations
 """
     AbstractInterpolation{T}
 
-Supertype of all interpolation objects in DataInterpolations.jl, where `T` is the element
-type of the interpolated values.
+Supertype of interpolation objects in DataInterpolations.jl, where `T` is the element type
+of the interpolated values. Use this type to dispatch on interpolations independently of
+the interpolation method.
 
-Every subtype is callable as `A(t)` to evaluate the interpolation at `t`, and supports
-[`DataInterpolations.derivative`](@ref) and [`DataInterpolations.integral`](@ref). Use it
-to dispatch on interpolations of any method.
+## Interface rules
 
-## Examples
+A concrete subtype must provide `u` and `t` fields. The entries of `t` are the ordered
+sample locations and the samples in `u` correspond to those locations along its last
+dimension. For scalar-valued data, `u` is a vector; for array-valued data, the last
+dimension of `u` indexes the samples. The generic methods also expect the subtype to
+provide `iguesser`, `extrapolation_left`, and `extrapolation_right` fields.
+
+# Fields
+
+- `u`: data values, with samples indexed along the last dimension.
+- `t`: ordered sample locations corresponding to the samples in `u`.
+- `iguesser`: reusable interval-search state.
+- `extrapolation_left`, `extrapolation_right`: out-of-range evaluation modes.
+
+The following developer hooks define the behavior of a new interpolation method:
+
+- [`DataInterpolations._interpolate`](@ref): evaluate one sample at a scalar location.
+- [`DataInterpolations._derivative`](@ref): evaluate the first derivative at a scalar
+  location. At a knot, return the left derivative, matching [`derivative`](@ref).
+- [`DataInterpolations._integral`](@ref): integrate one interval when analytic integration
+  is supported. A subtype that does not have an `I` field automatically reports
+  `IntegralNotFoundError` from [`integral`](@ref).
+
+These hooks are developer API: implement them when adding a new interpolation method, but
+call the generic `A(t)`, [`derivative`](@ref), and [`integral`](@ref) interfaces from user
+code. Implementations should preserve the shape of one data point in all three operations
+and should honor the extrapolation fields for out-of-range locations.
+
+# Examples
 
 ```jldoctest
 using DataInterpolations
@@ -44,7 +70,7 @@ Enumeration of extrapolation modes used by interpolation constructors through
 the `extrapolation`, `extrapolation_left`, and `extrapolation_right` keyword
 arguments.
 
-## Values
+# Values
 
   - `ExtrapolationType.None`: throw an error outside the interpolation interval.
   - `ExtrapolationType.Constant`: use the nearest endpoint value.
@@ -53,7 +79,7 @@ arguments.
   - `ExtrapolationType.Periodic`: wrap the query point periodically onto the data range.
   - `ExtrapolationType.Reflective`: reflect the query point back onto the data range.
 
-## Examples
+# Examples
 
 ```julia
 using DataInterpolations
@@ -156,6 +182,23 @@ end
     output_dim(x::AbstractInterpolation)
 
 Return the number of dimensions `ndims(x(t))` of interpolation `x` for a scalar `t`.
+
+# Arguments
+
+- `x`: the interpolation to inspect.
+
+# Returns
+
+- `Int`: the number of dimensions of one interpolated data point.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 2.0], [0.0, 1.0])
+output_dim(A)
+```
 """
 output_dim(x::AbstractInterpolation) = _output_dim(x.u)
 _output_dim(::AbstractVector) = 0 # each value is a scalar
@@ -166,6 +209,23 @@ _output_dim(::AbstractArray{<:Any, N}) where {N} = N - 1 # each value is an arra
     output_size(x::AbstractInterpolation)
 
 Return the size `size(x(t))` of interpolation `x` for a scalar `t`.
+
+# Arguments
+
+- `x`: the interpolation to inspect.
+
+# Returns
+
+- `Tuple`: the size of one interpolated data point.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 2.0], [0.0, 1.0])
+output_size(A)
+```
 """
 output_size(x::AbstractInterpolation) = _output_size(x.u)
 _output_size(::AbstractVector{<:Number}) = ()
@@ -185,7 +245,9 @@ export output_dim, output_size
 # string.
 @static if VERSION >= v"1.11"
     include_string(
-        @__MODULE__, "public AbstractInterpolation, derivative, integral, invert_integral"
+        @__MODULE__,
+        "public AbstractInterpolation, derivative, integral, invert_integral, " *
+            "_interpolate, _derivative, _integral",
     )
 end
 

--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -11,13 +11,13 @@ interval to the left of the point is returned.
 Outside of the range of `A.t` the derivative of the extrapolation is returned, as
 determined by the `extrapolation_left` and `extrapolation_right` settings of `A`.
 
-## Arguments
+# Arguments
 
   - `A`: the interpolation object.
   - `t`: the point at which to evaluate the derivative.
   - `order`: the order of the derivative, either `1` or `2`. Defaults to `1`.
 
-## Examples
+# Examples
 
 ```jldoctest
 using DataInterpolations
@@ -150,6 +150,32 @@ function _extrapolate_derivative_right(A::SmoothedConstantInterpolation, t, orde
     end
 end
 
+"""
+    _derivative(A::AbstractInterpolation, t::Number, iguess)
+
+Developer hook used by [`derivative`](@ref) for an in-range scalar evaluation. Implement
+this method for a new [`AbstractInterpolation`](@ref) subtype. The returned value must
+have the same shape as one interpolated data point, and the value at a knot must be the
+left derivative because the public derivative interface is left-continuous at knots.
+
+`iguess` is the reusable search hint stored by the interpolation. Implementations should
+use it when locating the interval and must not replace it with a new mutable search state
+for every call.
+
+User code should call [`derivative`](@ref) rather than this developer hook.
+
+# Arguments
+
+- `A`: an [`AbstractInterpolation`](@ref) subtype.
+- `t`: an in-range scalar evaluation point.
+- `iguess`: the reusable interval-search state from `A.iguesser`.
+
+# Examples
+
+```julia
+DataInterpolations._derivative(A::MyInterpolation, t::Number, iguess) = 2.0
+```
+"""
 function _derivative(A::LinearInterpolation, t::Number, iguess)
     idx = get_idx(A, t, iguess; idx_shift = -1, ub_shift = -1, side = :first)
     slope = get_parameters(A, idx)

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -1,3 +1,23 @@
+"""
+    AbstractIntegralInverseInterpolation{T}
+
+Developer supertype for interpolation objects that evaluate the inverse of a cumulative
+integral. Subtypes retain the [`AbstractInterpolation`](@ref) call and derivative
+interfaces, with `u` representing the original time values and `t` representing cumulative
+integral values. The internal `itp` field stores the source interpolation used to evaluate
+the inverse derivative.
+
+Users should construct these objects with [`invert_integral`](@ref), rather than calling a
+concrete constructor directly. A new implementation must provide the same
+`_interpolate(A, t, iguess)` contract as [`DataInterpolations._interpolate`](@ref) and return
+the source interpolation's reciprocal value from `_derivative`.
+
+# Fields
+
+- `u`: the original interpolation's sample locations.
+- `t`: cumulative integral values used as inverse-interpolation locations.
+- `itp`: the source interpolation used to evaluate the inverse derivative.
+"""
 abstract type AbstractIntegralInverseInterpolation{T} <: AbstractInterpolation{T} end
 
 """
@@ -9,9 +29,24 @@ Creates the inverted integral interpolation object from the given interpolation.
   - `A.u` must be a number type (on which an ordering is defined)
   - This is currently only supported for `ConstantInterpolation` and `LinearInterpolation`
 
-## Arguments
+# Arguments
 
   - `A`: interpolation object satisfying the above requirements
+
+# Returns
+
+- An [`AbstractIntegralInverseInterpolation`](@ref) that maps an integrated value back to
+  its time location.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 2.0, 3.0], [0.0, 1.0, 2.0])
+A_inverse = invert_integral(A)
+A_inverse(1.0)
+```
 """
 invert_integral(::AbstractInterpolation) = throw(IntegralInverseNotFoundError())
 
@@ -27,11 +62,21 @@ end
 It is the interpolation of the inverse of the integral of a `LinearInterpolation`.
 Can be easily constructed with `invert_integral(A::LinearInterpolation{<:AbstractVector{<:Number}})`
 
-## Arguments
+# Arguments
 
   - `u` : Given by `A.t`
   - `t` : Given by `A.I` (the cumulative integral of `A`)
   - `A` : The `LinearInterpolation` object
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 2.0, 3.0], [0.0, 1.0, 2.0])
+A_inverse = invert_integral(A)
+A_inverse(1.0)
+```
 """
 struct LinearInterpolationIntInv{uType, tType, itpType, T, propsType} <:
     AbstractIntegralInverseInterpolation{T}
@@ -98,11 +143,21 @@ end
 It is the interpolation of the inverse of the integral of a `ConstantInterpolation`.
 Can be easily constructed with `invert_integral(A::ConstantInterpolation{<:AbstractVector{<:Number}})`
 
-## Arguments
+# Arguments
 
   - `u` : Given by `A.t`
   - `t` : Given by `A.I` (the cumulative integral of `A`)
   - `A` : The `ConstantInterpolation` object
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = ConstantInterpolation([1.0, 2.0, 3.0], [0.0, 1.0, 2.0])
+A_inverse = invert_integral(A)
+A_inverse(1.0)
+```
 """
 struct ConstantInterpolationIntInv{uType, tType, itpType, T, propsType} <:
     AbstractIntegralInverseInterpolation{T}

--- a/src/integral_inverses.jl
+++ b/src/integral_inverses.jl
@@ -17,6 +17,9 @@ the source interpolation's reciprocal value from `_derivative`.
 - `u`: the original interpolation's sample locations.
 - `t`: cumulative integral values used as inverse-interpolation locations.
 - `itp`: the source interpolation used to evaluate the inverse derivative.
+
+Implementations also provide the interval-search fields described for
+[`AbstractInterpolation`](@ref), including `iguesser`, `kind`, and `t_props`.
 """
 abstract type AbstractIntegralInverseInterpolation{T} <: AbstractInterpolation{T} end
 

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -15,13 +15,13 @@ Interpolation types with no analytical antiderivative — `LagrangeInterpolation
 `IntegralNotFoundError`; use a numerical integrator such as
 [Integrals.jl](https://docs.sciml.ai/Integrals/stable/) for those.
 
-## Arguments
+# Arguments
 
   - `A`: the interpolation object.
   - `t`: the upper bound, with `first(A.t)` used as the lower bound.
   - `t1`, `t2`: the lower and upper bounds.
 
-## Examples
+# Examples
 
 ```jldoctest
 using DataInterpolations
@@ -284,6 +284,33 @@ function _extrapolate_integral_right(A::SmoothedConstantInterpolation, t)
     end
 end
 
+"""
+    _integral(A::AbstractInterpolation, idx::Integer, t1::Number, t2::Number)
+
+Developer hook used by [`integral`](@ref) to integrate one interval of an interpolation.
+Implement this method for a new interpolation subtype that supports analytic integration.
+`idx` identifies the interval `[A.t[idx], A.t[idx + 1]]`; the method must return the
+integral over the requested subinterval `[t1, t2]`, preserving the shape of one data point.
+
+The subtype must also provide an `I` field containing cached cumulative integrals when
+`cache_parameters` is true. If analytic integration is not supported, omit `I` and let the
+generic public method report `IntegralNotFoundError`.
+
+User code should call [`integral`](@ref) rather than this developer hook.
+
+# Arguments
+
+- `A`: an [`AbstractInterpolation`](@ref) subtype.
+- `idx`: the interval index, with bounds `A.t[idx]` and `A.t[idx + 1]`.
+- `t1`, `t2`: the requested interval bounds.
+
+# Examples
+
+```julia
+DataInterpolations._integral(A::MyInterpolation, idx::Integer, t1::Number, t2::Number) =
+    2 * (t2 - t1)
+```
+"""
 function _integral(
         A::LinearInterpolation{<:AbstractArray{<:Number}},
         idx::Number, t1::Number, t2::Number

--- a/src/interpolation_caches.jl
+++ b/src/interpolation_caches.jl
@@ -6,25 +6,34 @@
 It is the method of interpolating between the data points using a linear polynomial. For any point, two data points one each side are chosen and connected with a line.
 Extrapolation extends the last linear polynomial on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation
     computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LinearInterpolation([1.0, 3.0], [0.0, 1.0])
+A(0.5)
+```
 """
 struct LinearInterpolation{
         uType, tType, IType, pType, T, propsType,
@@ -89,25 +98,34 @@ end
 It is the method of interpolating between the data points using quadratic polynomials. For any point, three data points nearby are taken to fit a quadratic polynomial.
 Extrapolation extends the last quadratic polynomial on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
   - `mode`: `:Forward` or `:Backward`. If `:Forward`, two data points ahead of the point and one data point behind is taken for interpolation. If `:Backward`, two data points behind and one ahead is taken for interpolation.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = QuadraticInterpolation([1.0, 4.0, 9.0], [1.0, 2.0, 3.0])
+A(2.5)
+```
 """
 struct QuadraticInterpolation{uType, tType, IType, pType, T, propsType} <:
     AbstractInterpolation{T}
@@ -174,25 +192,33 @@ end
 
 It is the method of interpolation using Lagrange polynomials of (k-1)th order passing through all the data points where k is the number of data points.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
   - `n`: order of the polynomial. Currently only (k-1)th order where k is the number of data points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+A = LagrangeInterpolation([1.0, 4.0, 9.0], [1.0, 2.0, 3.0])
+A(2.5)
+```
 """
 struct LagrangeInterpolation{uType, tType, T, bcacheType, propsType} <:
     AbstractInterpolation{T}
@@ -255,12 +281,12 @@ end
 It is a spline interpolation built from cubic polynomials. It forms a continuously differentiable function. For more details, refer: [https://en.wikipedia.org/wiki/Akima_spline](https://en.wikipedia.org/wiki/Akima_spline).
 Extrapolation extends the last cubic polynomial on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `modified`: if `true`, use the modified Akima (makima) formula for the slopes at the knots,
     which adds an extra term `|m_{i+1} + m_i| / 2` to each weight. Tends to reduce overshoot
@@ -271,13 +297,22 @@ Extrapolation extends the last cubic polynomial on each side.
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = AkimaInterpolation([1.0, 4.0, 9.0, 16.0], [1.0, 2.0, 3.0, 4.0])
+A(2.5)
+```
 """
 struct AkimaInterpolation{
         uType, tType, IType, bType, cType, dType, T, propsType,
@@ -420,25 +455,34 @@ It is the method of interpolating using a constant polynomial. For any point, tw
 If it is `:left`, then the value at the left point is chosen and if it is `:right`, the value at the right point is chosen.
 Extrapolation extends the last constant polynomial at the end points on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `dir`: indicates which value should be used for interpolation (`:left` or `:right`).
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = ConstantInterpolation([1.0, 2.0, 3.0], [0.0, 1.0, 2.0])
+A(0.5)
+```
 """
 struct ConstantInterpolation{uType, tType, IType, T, propsType} <:
     AbstractInterpolation{T}
@@ -501,12 +545,12 @@ value transitions to make the curve continuously differentiable while the integr
 drifts far from the integral of constant interpolation. `u[end]` is ignored,
 except when using extrapolation types `Constant` or `Extension`.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `d_max`: Around each time point `tᵢ` there is a continuously differentiable (quadratic) transition between `uᵢ₋₁` and `uᵢ`,
     on the interval `[tᵢ - d, tᵢ + d]`. The distance `d` is determined as `d = min((tᵢ - tᵢ₋₁)/2, (tᵢ₊₁ - tᵢ)/2, d_max)`.
@@ -514,13 +558,22 @@ except when using extrapolation types `Constant` or `Extension`.
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` (also made smooth at the boundaries) and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = SmoothedConstantInterpolation([1.0, 2.0, 3.0], [0.0, 1.0, 2.0])
+A(0.5)
+```
 """
 struct SmoothedConstantInterpolation{
         uType, tType, IType, dType, cType, dmaxType, T, propsType,
@@ -586,24 +639,33 @@ end
 It is a spline interpolation using piecewise quadratic polynomials between each pair of data points. Its first derivative is also continuous.
 Extrapolation extends the last quadratic polynomial on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = QuadraticSpline([1.0, 4.0, 9.0], [1.0, 2.0, 3.0])
+A(2.5)
+```
 """
 struct QuadraticSpline{
         uType, tType, IType, pType, kType, cType, scType, T, propsType,
@@ -729,24 +791,33 @@ end
 It is a spline interpolation using piecewise cubic polynomials between each pair of data points. Its first and second derivative is also continuous.
 Second derivative on both ends are zero, which are also called "natural" boundary conditions. Extrapolation extends the last cubic polynomial on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = CubicSpline([1.0, 4.0, 9.0, 16.0], [1.0, 2.0, 3.0, 4.0])
+A(2.5)
+```
 """
 struct CubicSpline{uType, tType, IType, pType, hType, zType, T, propsType} <:
     AbstractInterpolation{T}
@@ -930,7 +1001,7 @@ is constructed directly from the data sites `t`, and basis functions are evaluat
 values (no reparameterization). For more information, refer to de Boor's "A Practical Guide to Splines".
 Extrapolation is a constant polynomial of the end points on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
@@ -941,19 +1012,27 @@ Extrapolation is a constant polynomial of the end points on each side.
     `d >= 3`; constructing such an interpolation warns, and the result may deviate from the data by orders of
     magnitude between the data points even though it still passes through them.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+A = BSplineInterpolation([1.0, 4.0, 9.0, 16.0], [1.0, 2.0, 3.0, 4.0], 2, :Average)
+A(2.5)
+```
 """
 struct BSplineInterpolation{uType, tType, kType, cType, scType, T, propsType} <:
     AbstractInterpolation{T}
@@ -1111,7 +1190,7 @@ end
 It is a regression based B-spline. The argument choices are the same as the `BSplineInterpolation`, with the additional parameter `h < length(t)` which is the number of control points to use, with smaller `h` indicating more smoothing.
 Extrapolation is a constant polynomial of the end points on each side.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
@@ -1119,19 +1198,27 @@ Extrapolation is a constant polynomial of the end points on each side.
   - `h`: number of control points to use.
   - `knotVecType`: symbol to knot vector, `:Uniform` for uniform knot vector, `:Average` for average spaced knot vector.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+A = BSplineApprox([1.0, 4.0, 9.0, 16.0], [1.0, 2.0, 3.0, 4.0], 2, 3, :Average)
+A(2.5)
+```
 """
 struct BSplineApprox{
         uType, tType, kType, cType, scType, T, propsType,
@@ -1337,25 +1424,34 @@ end
 
 It is a Cubic Hermite interpolation, which is a piece-wise third degree polynomial such that the value and the first derivative are equal to given values in the data points.
 
-## Arguments
+# Arguments
 
   - `du`: the derivative at the data points.
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = CubicHermiteSpline([2.0, 4.0, 6.0], [1.0, 4.0, 9.0], [1.0, 2.0, 3.0])
+A(2.5)
+```
 """
 struct CubicHermiteSpline{
         uType, tType, IType, duType, pType, T, propsType,
@@ -1421,24 +1517,33 @@ It is a PCHIP Interpolation, which is a type of [`CubicHermiteSpline`](@ref) whe
 in such a way that the interpolation never overshoots the data. See [here](https://www.mathworks.com/content/dam/mathworks/mathworks-dot-com/moler/interp.pdf),
 section 3.4 for more details.
 
-## Arguments
+# Arguments
 
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = PCHIPInterpolation([1.0, 4.0, 9.0, 16.0], [1.0, 2.0, 3.0, 4.0])
+A(2.5)
+```
 """
 function PCHIPInterpolation(u, t; kwargs...)
     u, t = munge_data(u, t)
@@ -1452,26 +1557,37 @@ end
 
 It is a Quintic Hermite interpolation, which is a piece-wise fifth degree polynomial such that the value and the first and second derivative are equal to given values in the data points.
 
-## Arguments
+# Arguments
 
   - `ddu`: the second derivative at the data points.
   - `du`: the derivative at the data points.
   - `u`: data points.
   - `t`: time points.
 
-## Keyword Arguments
+# Keywords
 
   - `extrapolation`: The extrapolation type applied left and right of the data. Possible options
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `cache_parameters`: precompute parameters at initialization for faster interpolation computations. Note: if activated, `u` and `t` should not be modified. Defaults to `false`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
+
+# Examples
+
+```julia
+using DataInterpolations
+
+A = QuinticHermiteSpline(
+    [0.0, 0.0, 0.0], [2.0, 4.0, 6.0], [1.0, 4.0, 9.0], [1.0, 2.0, 3.0],
+)
+A(2.5)
+```
 """
 struct QuinticHermiteSpline{
         uType, tType, IType, duType, dduType, pType, T, propsType,
@@ -1587,7 +1703,7 @@ end
 Interpolate in a C¹ smooth way through the data with unit speed by approximating
 an interpolation (the shape interpolation) with line segments and circle segments.
 
-## Arguments
+# Arguments
 
   - `u`: The data to be interpolated in matrix form; (ndim, ndata).
 
@@ -1595,7 +1711,7 @@ NOTE: With this method it is not possible to pass keyword arguments to the const
 If you want to do this, construct the shape interpolation yourself and use the
 `SmoothArcLengthInterpolation(shape_itp::AbstractInterpolation; kwargs...)` method.
 
-## Keyword Arguments
+# Keywords
 
   - `t`: The time points of the shape interpolation. By default given by the cumulative sum of the Euclidean
     distances between the points `u`.
@@ -1607,13 +1723,22 @@ If you want to do this, construct the shape interpolation yourself and use the
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+u = [0.0 1.0 2.0; 0.0 1.0 0.0]
+A = SmoothArcLengthInterpolation(u; m = 4)
+A(0.5)
+```
 """
 function SmoothArcLengthInterpolation(
         u::AbstractMatrix{U};
@@ -1644,12 +1769,12 @@ end
 
 Approximate the `shape_itp` with a C¹ unit speed interpolation using line segments and circle segments.
 
-## Arguments
+# Arguments
 
   - `shape_itp`: The interpolation to be approximated. Note that
     for the `SmoothArcLengthInterpolation` to be C¹ smooth, the `shape_itp` must be C¹ smooth as well.
 
-## Keyword Arguments
+# Keywords
 
   - `m`: The number of points at which the shape interpolation is evaluated in each interval between time points.
     The `SmoothArcLengthInterpolation` converges to the shape interpolation (in shape) as m → ∞.
@@ -1657,13 +1782,22 @@ Approximate the `shape_itp` with a C¹ unit speed interpolation using line segme
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+shape = QuadraticSpline([[0.0, 0.0], [1.0, 1.0], [2.0, 0.0]], [0.0, 1.0, 2.0])
+A = SmoothArcLengthInterpolation(shape; m = 4)
+A(0.5)
+```
 """
 function SmoothArcLengthInterpolation(
         shape_itp::AbstractInterpolation;
@@ -1717,14 +1851,14 @@ end
 Make a C¹ smooth unit speed interpolation through the given data with the given tangents using line
 segments and circle segments.
 
-## Arguments
+# Arguments
 
   - `u`: The data to be interpolated in matrix form; (ndim, ndata).
   - `d`: The tangents to the curve in the points `u`.
   - `make_intersections`: Whether additional (point, tangent) pairs have to be added in between the provided
     data to ensure that the consecutive (tangent) lines intersect. Defaults to `Val(true)`.
 
-## Keyword Arguments
+# Keywords
 
   - `shape_itp`: The interpolation that is being approximated, if one exists. Note that this
     interpolation is not being used; it is just passed along to keep track of where the shape
@@ -1733,13 +1867,23 @@ segments and circle segments.
     are `ExtrapolationType.None` (default), `ExtrapolationType.Constant`, `ExtrapolationType.Linear`
     `ExtrapolationType.Extension`, `ExtrapolationType.Periodic` and `ExtrapolationType.Reflective`.
   - `extrapolation_left`: The extrapolation type applied left of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `extrapolation_right`: The extrapolation type applied right of the data. See `extrapolation` for
-    the possible options. This keyword is ignored if `extrapolation != Extrapolation.none`.
+    the possible options. This keyword is ignored if `extrapolation != ExtrapolationType.None`.
   - `search_properties`: a pre-built `FindFirstFunctions.SearchProperties` for `t`, used
     to skip the construction-time knot probe or override its result (e.g. built with
     `is_uniform = true`). Defaults to `nothing`, which probes `t` automatically.
 
+# Examples
+
+```julia
+using DataInterpolations
+
+u = [0.0 1.0 2.0; 0.0 1.0 0.0]
+d = [1.0 1.0 1.0; 1.0 0.0 -1.0]
+A = SmoothArcLengthInterpolation(u, d)
+A(0.5)
+```
 """
 function SmoothArcLengthInterpolation(
         u::AbstractMatrix,

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -1,3 +1,38 @@
+"""
+    _interpolate(A::AbstractInterpolation, t::Number)
+    _interpolate(A::AbstractInterpolation, t::Number, iguess)
+
+Developer hook used by the generic call interface `A(t)`. The two-argument method handles
+the configured extrapolation behavior and delegates an in-range scalar evaluation to the
+three-argument method. New interpolation subtypes should implement
+`_interpolate(A, t, iguess)`, where `iguess` is a reusable search hint supplied by the
+interpolation object.
+
+The implementation must return one interpolated data point with the same shape as a single
+sample in `A.u`. It must not mutate `A.u` or `A.t` while evaluating. User code should call
+`A(t)` instead of this developer hook.
+
+# Arguments
+
+- `A`: an [`AbstractInterpolation`](@ref) subtype.
+- `t`: the scalar evaluation point.
+- `iguess`: the reusable interval-search state from `A.iguesser` for the three-argument
+  method.
+
+# Examples
+
+```julia
+struct MyInterpolation <: DataInterpolations.AbstractInterpolation{Float64}
+    u::Vector{Float64}
+    t::Vector{Float64}
+    iguesser
+    extrapolation_left::DataInterpolations.ExtrapolationType.T
+    extrapolation_right::DataInterpolations.ExtrapolationType.T
+end
+
+DataInterpolations._interpolate(A::MyInterpolation, t::Number, iguess) = 2t
+```
+"""
 function _interpolate(A, t)
     return if t < first(A.t)
         _extrapolate_left(A, t)

--- a/test/Misc/public_api.jl
+++ b/test/Misc/public_api.jl
@@ -6,8 +6,9 @@ using DataInterpolations, Test
 @testset "Public API" begin
     @testset "$name" for name in
         (
-            :AbstractInterpolation, :derivative, :integral, :invert_integral,
-            :_interpolate, :_derivative, :_integral,
+            :AbstractInterpolation, :AbstractIntegralInverseInterpolation,
+            :derivative, :integral, :invert_integral, :_interpolate, :_derivative,
+            :_integral,
         )
         @test isdefined(DataInterpolations, name)
         if VERSION >= v"1.11"

--- a/test/Misc/public_api.jl
+++ b/test/Misc/public_api.jl
@@ -5,7 +5,10 @@ using DataInterpolations, Test
 # them is checked by Aqua in the QA group.
 @testset "Public API" begin
     @testset "$name" for name in
-        (:AbstractInterpolation, :derivative, :integral, :invert_integral)
+        (
+            :AbstractInterpolation, :derivative, :integral, :invert_integral,
+            :_interpolate, :_derivative, :_integral,
+        )
         @test isdefined(DataInterpolations, name)
         if VERSION >= v"1.11"
             @test Base.ispublic(DataInterpolations, name)

--- a/test/abstract_interface.jl
+++ b/test/abstract_interface.jl
@@ -1,0 +1,57 @@
+using DataInterpolations, Test
+
+struct GenericTestInterpolation <: DataInterpolations.AbstractInterpolation{Float64}
+    u::Vector{Float64}
+    t::Vector{Float64}
+    I::Vector{Float64}
+    iguesser
+    extrapolation_left::DataInterpolations.ExtrapolationType.T
+    extrapolation_right::DataInterpolations.ExtrapolationType.T
+    kind
+    t_props
+    cache_parameters::Bool
+end
+
+# The contract test supplies only the developer hooks. All assertions below exercise the
+# public generic evaluation, derivative, integral, and shape interfaces.
+function DataInterpolations._interpolate(
+        ::GenericTestInterpolation, t::Number, ::Any
+    )
+    return 2t
+end
+
+function DataInterpolations._derivative(
+        ::GenericTestInterpolation, ::Number, ::Any
+    )
+    return 2.0
+end
+
+function DataInterpolations._integral(
+        ::GenericTestInterpolation, ::Integer, t1::Number, t2::Number
+    )
+    return 2 * (t2 - t1)
+end
+
+@testset "AbstractInterpolation contract" begin
+    seed = LinearInterpolation([0.0, 2.0, 4.0], [0.0, 1.0, 2.0])
+    A = GenericTestInterpolation(
+        [0.0, 2.0, 4.0], [0.0, 1.0, 2.0], Float64[], seed.iguesser,
+        seed.extrapolation_left, seed.extrapolation_right, seed.kind, seed.t_props, false,
+    )
+
+    @test A isa DataInterpolations.AbstractInterpolation
+    @test A(0.5) == 1.0
+    @test A([0.5, 1.5]) == [1.0, 3.0]
+
+    out = zeros(2)
+    @test A(out, [0.5, 1.5]) === out
+    @test out == [1.0, 3.0]
+
+    @test DataInterpolations.derivative(A, 0.5) == 2.0
+    @test DataInterpolations.derivative(A, 0.5, 2) == 0.0
+    @test DataInterpolations.integral(A, 1.5) == 3.0
+    @test DataInterpolations.integral(A, 0.5, 1.5) == 2.0
+
+    @test DataInterpolations.output_dim(A) == 0
+    @test DataInterpolations.output_size(A) == ()
+end

--- a/test/abstract_interface.jl
+++ b/test/abstract_interface.jl
@@ -1,4 +1,5 @@
 using DataInterpolations, Test
+using FindFirstFunctions
 
 struct GenericTestInterpolation <: DataInterpolations.AbstractInterpolation{Float64}
     u::Vector{Float64}
@@ -7,8 +8,8 @@ struct GenericTestInterpolation <: DataInterpolations.AbstractInterpolation{Floa
     iguesser
     extrapolation_left::DataInterpolations.ExtrapolationType.T
     extrapolation_right::DataInterpolations.ExtrapolationType.T
-    kind
-    t_props
+    kind::FindFirstFunctions.StrategyKind
+    t_props::FindFirstFunctions.SearchProperties
     cache_parameters::Bool
 end
 
@@ -33,10 +34,13 @@ function DataInterpolations._integral(
 end
 
 @testset "AbstractInterpolation contract" begin
-    seed = LinearInterpolation([0.0, 2.0, 4.0], [0.0, 1.0, 2.0])
+    t = [0.0, 1.0, 2.0]
+    t_props = FindFirstFunctions.SearchProperties(t)
     A = GenericTestInterpolation(
-        [0.0, 2.0, 4.0], [0.0, 1.0, 2.0], Float64[], seed.iguesser,
-        seed.extrapolation_left, seed.extrapolation_right, seed.kind, seed.t_props, false,
+        [0.0, 2.0, 4.0], t, Float64[], FindFirstFunctions.Guesser(t),
+        DataInterpolations.ExtrapolationType.None,
+        DataInterpolations.ExtrapolationType.None,
+        FindFirstFunctions.Auto(t, t_props).kind, t_props, false,
     )
 
     @test A isa DataInterpolations.AbstractInterpolation


### PR DESCRIPTION
## Summary

- Document every exported and Julia `public` interpolation API at its definition, with SciMLStyle arguments, keywords, returns/fields where applicable, and runnable examples.
- Add a rendered abstract interpolation interface page covering the developer hooks `_interpolate`, `_derivative`, and `_integral`.
- Add a generic `AbstractInterpolation` contract test that exercises evaluation, vectorized/in-place evaluation, derivatives, integrals, and shape utilities through the public generic interface.
- Raise the package minor version to `9.3.0` because the three extension hooks are newly declared Julia `public` developer API.

The existing cache implementation fields remain private; this PR does not make caches user-facing API. There are no `@doc` attachment shims and no repository-specific public-doc, rendered, doctest, or reexport overrides.

## Verification

- `julia --startup-file=no -e 'using Runic; exit(Runic.main(ARGS))' -- --check --diff --verbose src ext test` — all 35 files passed.
- `typos --config .typos.toml ...` over all changed source, docs, project, and test files — passed.
- `julia --startup-file=no --project=. -e 'using DataInterpolations, Test; include("test/abstract_interface.jl")'` — `AbstractInterpolation contract | 11 11`.
- `GROUP=QA julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` — `QA/alloc_tests.jl | 16 16`; `QA/qa.jl | 20 20`; SciMLTesting `2.10.0` resolved under the declared `2.4` compat floor.
- `julia --startup-file=no --project=docs -e 'pushfirst!(LOAD_PATH, pwd()); include("docs/make.jl")'` — Documenter completed with exit code 0, including doctests, cross-references, document checks, rendering, and link checking.
- Julia API inventory confirmed all exported/public names have nonempty source docstrings; all seven non-exported/public interface names are rendered in `docs/src/abstract_interpolation.md` or `docs/src/inverting_integrals.md`.

The local docs build reports only existing large HTML example-representation warnings and skips deployment outside CI.

Please ignore this draft until reviewed by @ChrisRackauckas.
