### PR TITLE
Release 10.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "9.5.0"
+version = "10.0.0"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Re-cut the current API as a breaking major.

#506 (Curvefit migrated from Optim.jl to CurveFit.jl) and #511 (BSpline reparameterization) are breaking and have been shipping under the 9.x series since 9.2.0. Bumping to 10.0.0 so downstream `DataInterpolations = "9"` bounds stop resolving to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R