### PR TITLE
refactor: improve performance few methods

### DIFF
--- a/src/derivatives.jl
+++ b/src/derivatives.jl
@@ -225,7 +225,7 @@ function _lagrange_node_derivative(
     @views for j in eachindex(A.t)
         j == k && continue
         coef = (A.p.w[j] * invw_k) / (A.t[k] - A.t[j])
-        der = der + coef * (values[:, j] - values[:, k])
+        @. der += coef * (values[:, j] - values[:, k])
     end
     return der
 end
@@ -264,17 +264,20 @@ end
 function _derivative(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number)
     idx = _searchsortedfirst(A.t, t)
     !isnothing(idx) && return _lagrange_node_derivative(A, idx, A.u)
-    N = zero(A.p.wu[:, 1])
-    D = zero(A.t[1])
-    N′ = zero(A.p.wu[:, 1])
-    D′ = zero(A.t[1])
+    # Preallocate wide enough for `t` (e.g. a ForwardDiff `Dual`) so the loop below can
+    # accumulate in place instead of allocating new arrays every iteration.
+    T = promote_type(eltype(A.p.wu), typeof(t))
+    N = zeros(T, size(A.p.wu, 1))
+    D = zero(T)
+    N′ = zeros(T, size(A.p.wu, 1))
+    D′ = zero(T)
     @views for i in eachindex(A.t)
         invti = inv(t - A.t[i])
         wi_inv = A.p.w[i] * invti
         D += wi_inv
         D′ -= wi_inv * invti
-        N = N + A.p.wu[:, i] * invti
-        N′ = N′ - A.p.wu[:, i] * invti^2
+        @. N += A.p.wu[:, i] * invti
+        @. N′ -= A.p.wu[:, i] * invti^2
     end
     return @. (N′ * D - N * D′) / D^2
 end
@@ -366,12 +369,10 @@ function _derivative(A::CubicSpline{<:AbstractArray}, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt₁ = t - A.t[idx]
     Δt₂ = A.t[idx + 1] - t
-    ax = axes(A.z)[1:(end - 1)]
-    dI = (-A.z[ax..., idx] * Δt₂^2 + A.z[ax..., idx + 1] * Δt₁^2) / (2A.h[idx + 1])
     c₁, c₂ = get_parameters(A, idx)
-    dC = c₁
-    dD = -c₂
-    return dI + dC + dD
+    denom = 2A.h[idx + 1]
+    return @. (-$(_u_view(A.z, idx)) * Δt₂^2 + $(_u_view(A.z, idx + 1)) * Δt₁^2) / denom +
+        c₁ - c₂
 end
 
 function _derivative(A::BSplineInterpolation{<:AbstractVector{<:Number}}, t::Number, iguess)
@@ -430,7 +431,6 @@ function _derivative(
         return isempty(searchsorted(A.t, t)) ? zero(A.u[:, 1]) :
             typed_nan(A.u) .* A.u[:, 1]
     end
-    ax_u = axes(A.u)[1:(end - 1)]
     n = length(A.t)
     # Stack-allocated basis window (see `_interpolate`): must be reentrant, #532.
     vals, offset, m = bspline_nonzero_coefficients(A.d - 1, A.k, t, n)
@@ -438,15 +438,15 @@ function _derivative(
     if t == A.t[1]
         denom = A.k[A.d + 2] - A.k[2]
         if denom != 0
-            ducum = (A.c[ax_u..., 2] - A.c[ax_u..., 1]) / denom
+            ducum = (_u_view(A.c, 2) - _u_view(A.c, 1)) / denom
         end
     else
         @inbounds for i in 1:(n - 1)
             denom = A.k[i + A.d + 1] - A.k[i + 1]
             l = i + 1 - offset
             if denom != 0 && 1 <= l <= m
-                ducum = ducum +
-                    vals[l] * (A.c[ax_u..., i + 1] - A.c[ax_u..., i]) / denom
+                coef = vals[l] / denom
+                ducum = ducum + coef * (_u_view(A.c, i + 1) - _u_view(A.c, i))
             end
         end
     end
@@ -507,21 +507,21 @@ function _derivative(
         return isempty(searchsorted(A.t, t)) ? zero(A.u[:, 1]) :
             typed_nan(A.u) .* A.u[:, 1]
     end
-    ax_u = axes(A.u)[1:(end - 1)]
     # Stack-allocated basis window (see `_interpolate`): must be reentrant, #532.
     vals, offset, m = bspline_nonzero_coefficients(A.d - 1, A.k, t, A.h)
     ducum = zeros(size(A.u)[1:(end - 1)]...)
     if t == A.t[1]
         denom = A.k[A.d + 2] - A.k[2]
         if denom != 0
-            ducum = (A.c[ax_u..., 2] - A.c[ax_u..., 1]) / denom
+            ducum = (_u_view(A.c, 2) - _u_view(A.c, 1)) / denom
         end
     else
         @inbounds for i in 1:(A.h - 1)
             denom = A.k[i + A.d + 1] - A.k[i + 1]
             l = i + 1 - offset
             if denom != 0 && 1 <= l <= m
-                ducum += vals[l] * (A.c[ax_u..., i + 1] - A.c[ax_u..., i]) / denom
+                coef = vals[l] / denom
+                ducum = ducum + coef * (_u_view(A.c, i + 1) - _u_view(A.c, i))
             end
         end
     end

--- a/src/integrals.jl
+++ b/src/integrals.jl
@@ -426,9 +426,8 @@ function _integral(
     tᵢ = A.t[idx]
     tᵢ₊₁ = A.t[idx + 1]
     c₁, c₂ = get_parameters(A, idx)
-    ax = axes(A.z)[1:(end - 1)]
-    zᵢ = A.z[ax..., idx]
-    zᵢ₊₁ = A.z[ax..., idx + 1]
+    zᵢ = _u_view(A.z, idx)
+    zᵢ₊₁ = _u_view(A.z, idx + 1)
     zero_ = zero(c₁)
     return integrate_cubic_polynomial(
         t1, t2, tᵢ, zero_, c₁, zero_, zᵢ₊₁ / (6A.h[idx + 1])

--- a/src/interpolation_methods.jl
+++ b/src/interpolation_methods.jl
@@ -633,8 +633,11 @@ end
 function _interpolate(A::LagrangeInterpolation{<:AbstractMatrix}, t::Number, iguess)
     idx = _searchsortedfirst(A.t, t)
     !isnothing(idx) && return A.u[:, idx]
-    N = zero(A.p.wu[:, 1])
-    D = zero(A.t[1])
+    # Preallocate wide enough for `t` (e.g. a ForwardDiff `Dual`) so the loop below can
+    # accumulate in place instead of allocating a new array every iteration.
+    T = promote_type(eltype(A.p.wu), typeof(t))
+    N = zeros(T, size(A.p.wu, 1))
+    D = zero(T)
     @views for i in eachindex(A.t)
         invti = inv(t - A.t[i])
         D += A.p.w[i] * invti
@@ -1106,12 +1109,10 @@ function _interpolate(A::CubicSpline{<:AbstractArray}, t::Number, iguess)
     idx = get_idx(A, t, iguess)
     Δt₁ = t - A.t[idx]
     Δt₂ = A.t[idx + 1] - t
-    ax = axes(A.z)[1:(end - 1)]
-    I = (A.z[ax..., idx] * Δt₂^3 + A.z[ax..., idx + 1] * Δt₁^3) / (6A.h[idx + 1])
     c₁, c₂ = get_parameters(A, idx)
-    C = c₁ * Δt₁
-    D = c₂ * Δt₂
-    return I + C + D
+    denom = 6A.h[idx + 1]
+    return @. ($(_u_view(A.z, idx)) * Δt₂^3 + $(_u_view(A.z, idx + 1)) * Δt₁^3) / denom +
+        c₁ * Δt₁ + c₂ * Δt₂
 end
 
 function (A::CubicSpline{<:AbstractVector{<:Number}})(
@@ -1307,13 +1308,12 @@ function _interpolate(
         t::Number,
         iguess
     )
-    ax_u = axes(A.u)[1:(end - 1)]
     n = length(A.t)
     # Stack-allocated basis window: evaluation must be reentrant for thread safety (#532)
     vals, offset, m = bspline_nonzero_coefficients(A.d, A.k, t, n)
     ucum = zeros(eltype(A.u), size(A.u)[1:(end - 1)]...)
     @inbounds for l in 1:m
-        ucum = ucum + (vals[l] * A.c[ax_u..., offset + l])
+        ucum = ucum + vals[l] * _u_view(A.c, offset + l)
     end
     return ucum
 end
@@ -1344,12 +1344,11 @@ end
 function _interpolate(
         A::BSplineApprox{<:AbstractArray{<:Number}}, t::Number, iguess
     )
-    ax_u = axes(A.u)[1:(end - 1)]
     # Stack-allocated basis window: evaluation must be reentrant for thread safety (#532)
     vals, offset, m = bspline_nonzero_coefficients(A.d, A.k, t, A.h)
     ucum = zeros(eltype(A.u), size(A.u)[1:(end - 1)]...)
     @inbounds for l in 1:m
-        ucum = ucum + (vals[l] * A.c[ax_u..., offset + l])
+        ucum = ucum + vals[l] * _u_view(A.c, offset + l)
     end
     return ucum
 end

--- a/src/parameter_caches.jl
+++ b/src/parameter_caches.jl
@@ -212,9 +212,8 @@ function cubic_spline_parameters(u::AbstractVector, h, z, idx)
 end
 
 function cubic_spline_parameters(u::AbstractArray, h, z, idx)
-    ax = axes(u)[1:(end - 1)]
-    c₁ = (u[ax..., idx + 1] / h[idx + 1] - z[ax..., idx + 1] * h[idx + 1] / 6)
-    c₂ = (u[ax..., idx] / h[idx + 1] - z[ax..., idx] * h[idx + 1] / 6)
+    c₁ = (_u_view(u, idx + 1) / h[idx + 1] - _u_view(z, idx + 1) * h[idx + 1] / 6)
+    c₂ = (_u_view(u, idx) / h[idx + 1] - _u_view(z, idx) * h[idx + 1] / 6)
     return c₁, c₂
 end
 


### PR DESCRIPTION
This PR improves performance of LagrangeInterpolation, CubicSpline and BSplines.


1. _u_view: replaces copying slice indexing (A.z[axes(A.z)[1:end-1]..., idx], which allocates a new array for generalized-dimension.
  Array getindex) with selectdim-based views, eliminating one allocation per access for matrix-valued u.
2. Type promotion: preallocating the Lagrange accumulator once as zeros(promote_type(eltype(A.p.wu), typeof(t)), ...) (wide enough to also hold a ForwardDiff.Dual t) lets the loop mutate it in place via @. instead of rebinding a freshly-allocated array on every iteration.

  btime / allocs, master -> now:

  LagrangeInterpolation  interpolate   457 ns / 3    -> 431 ns / 2
  LagrangeInterpolation  derivative    6.24 us / 207 -> 674 ns / 5
  CubicSpline            interpolate   722 ns / 21   -> 443 ns / 13
  CubicSpline            derivative    742 ns / 21   -> 467 ns / 13
  CubicSpline            integral      30.0 us / 952 -> 26.1 us / 802
  BSplineInterpolation   interpolate   565 ns / 13   -> 463 ns / 9
  BSplineInterpolation   derivative    809 ns / 20   -> 571 ns / 11
  BSplineApprox          interpolate   544 ns / 13   -> 459 ns / 9
  BSplineApprox          derivative    760 ns / 20   -> 530 ns / 11