### PR TITLE
fix: bound Mooncake constructor differentiation

### DIFF
--- a/ext/DataInterpolationsMooncakeExt.jl
+++ b/ext/DataInterpolationsMooncakeExt.jl
@@ -1,7 +1,8 @@
 module DataInterpolationsMooncakeExt
 
 using DataInterpolations: _interpolate, munge_data, AbstractInterpolation,
-    LinearInterpolation, QuadraticInterpolation, warn_if_ill_conditioned
+    LinearInterpolation, QuadraticInterpolation, check_min_length,
+    check_no_duplicate_t, warn_if_ill_conditioned
 using ChainRulesCore: ChainRulesCore
 using FindFirstFunctions: FindFirstFunctions
 using Mooncake: Mooncake, @from_chainrules, @zero_adjoint, MinimalCtx, DefaultCtx
@@ -66,5 +67,8 @@ end
 # Diagnostic only: returns `nothing` and just emits a warning. `@warn` expands to a
 # try/catch, which Mooncake cannot differentiate in reverse mode.
 @zero_adjoint DefaultCtx Tuple{typeof(warn_if_ill_conditioned), Any, Any, Any, Any, Any}
+@zero_adjoint DefaultCtx Tuple{typeof(check_min_length), Any, Any}
+@zero_adjoint DefaultCtx Tuple{typeof(check_min_length), Any, Any, Any}
+@zero_adjoint DefaultCtx Tuple{typeof(check_no_duplicate_t), Any, Any}
 
 end

--- a/test/Extensions/mooncake_tests.jl
+++ b/test/Extensions/mooncake_tests.jl
@@ -3,6 +3,18 @@ using ForwardDiff
 using Mooncake
 using Test
 
+@testset "Constructor validations" begin
+    function f(u)
+        DataInterpolations.check_no_duplicate_t(LinearInterpolation, u)
+        DataInterpolations.check_min_length(LinearInterpolation, u)
+        return sum(u)
+    end
+    u = [1.0, 2.0]
+    cache = Mooncake.prepare_gradient_cache(f, u)
+    _, (_, mgrad) = Mooncake.value_and_gradient!!(cache, f, u)
+    @test mgrad == ones(2)
+end
+
 # Differentiates a scalar accumulation sum over t w.r.t. u values.
 # sum(A(_t)) handles both scalar u (A returns Number) and matrix u (A returns Vector).
 function test_mooncake_ugrad(

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -15,8 +15,9 @@ using ChainRulesCore, Makie, Mooncake, Optim, SparseConnectivityTracer, Symbolic
 # allowed here instead.
 const DATAINTERPOLATIONS_INTERNALS = (
     :AbstractInterpolation, :CurvefitCache, :DerivativeNotFoundError,
-    :ExtrapolationError, :IntegralNotFoundError, :_interpolate, :derivative, :get_idx,
-    :get_show, :integral, :munge_data, :to_plottable, :warn_if_ill_conditioned,
+    :ExtrapolationError, :IntegralNotFoundError, :_interpolate, :check_min_length,
+    :check_no_duplicate_t, :derivative, :get_idx, :get_show, :integral, :munge_data,
+    :to_plottable, :warn_if_ill_conditioned,
 )
 
 run_qa(


### PR DESCRIPTION
## What changed and why

Marks `check_min_length` and `check_no_duplicate_t` as zero-adjoint operations in the Mooncake extension. [commit `80811209c5549414c7ed97695d85f692cd77de19`](https://github.com/SciML/DataInterpolations.jl/commit/80811209c5549414c7ed97695d85f692cd77de19) added these validation calls to `LinearInterpolation`; Mooncake then recursively derived the validation and exception-reporting path (including `nameof`), causing unbounded rule-construction resource growth before the first extension assertion ran.

The validations still execute normally in the primal call and still throw for invalid inputs. The new focused test differentiates through both validation overloads and verifies the unaffected gradient.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

### Failing before

The first existing `LinearInterpolation` u-gradient was extracted unchanged from `test/Extensions/mooncake_tests.jl` and run with a 12 GiB virtual-memory guard:

```text
ulimit -v 12582912
/usr/bin/time -v timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10.12 --project=test/Extensions --startup-file=no -e <LinearInterpolation u-gradient shard>
```

On current `master` (`80811209c5549414c7ed97695d85f692cd77de19`):

```text
begin prepare
ERROR: OutOfMemoryError()
...
Mooncake.LazyDerivedRule{Tuple{typeof(DataInterpolations.check_no_duplicate_t), Symbol, Vector{Float64}}, ...}
Mooncake.LazyDerivedRule{Tuple{typeof(DataInterpolations.check_min_length), Symbol, Int64, Int64}, ...}
Elapsed (wall clock) time: 6:24.47
Maximum resident set size (kbytes): 2930676
Exit status: 1
```

The identical shard on parent [commit `d0cb1e6ee5e1dc3a68bc03dc169a2565c0552b35`](https://github.com/SciML/DataInterpolations.jl/commit/d0cb1e6ee5e1dc3a68bc03dc169a2565c0552b35) passed in 58.31 s with 473,468 KiB peak RSS, bisecting the regression to `80811209c5549414c7ed97695d85f692cd77de19`.

### Passing after

The same capped shard on this branch:

```text
begin prepare
prepared
gradient=[182.0, -118.50000000000001, 8.999999999999998, 8.999999999999998, 8.999999999999998, 8.999999999999998, 8.999999999999998, 8.999999999999998, -118.5, 182.0]
Elapsed (wall clock) time: 0:50.24
Maximum resident set size (kbytes): 496812
Exit status: 0
```

Latest-compatible complete Extensions group:

```text
export GROUP=Extensions
ulimit -v 16777216
/usr/bin/time -v timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10.12 --startup-file=no -e "using Pkg; Pkg.activate(; temp = true); Pkg.develop(path = pwd()); Pkg.test(\"DataInterpolations\")"

Extensions/mooncake_tests.jl                 769/769
Extensions/sparseconnectivitytracer_tests.jl 660/660
Extensions/zygote_tests.jl                   29470/29470
Testing DataInterpolations tests passed
Elapsed: 28:23.77
Peak RSS: 3106932 KiB
```

Minimum-version complete Extensions group, using the separately proposed [dependency-floor patch](https://github.com/SciML/DataInterpolations.jl/pull/603) to keep the downgrade graph loadable:

```text
export GROUP=Extensions
ulimit -v 16777216
/usr/bin/time -v timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10.12 --project=. --startup-file=no -e "using Pkg; Pkg.test(; allow_reresolve = false)"

Extensions/dependency_extension_tests.jl    2/2
Extensions/mooncake_tests.jl                 768/768
Extensions/sparseconnectivitytracer_tests.jl 660/660
Extensions/zygote_tests.jl                   29470/29470
Testing DataInterpolations tests passed
Elapsed: 31:28.64
Peak RSS: 2860100 KiB
```

QA:

The first hosted run exposed the two new same-package helper imports to the existing extension-internal QA policy:

```text
all_explicit_imports_are_public: Error During Test
NonPublicExplicitImportsException
- check_min_length is not public in DataInterpolations
- check_no_duplicate_t is not public in DataInterpolations
QA/qa.jl | 19 pass, 1 error, 20 total
```

After adding those package-owned private names to the repository's existing `DATAINTERPOLATIONS_INTERNALS` tuple, the exact local QA group passed:

```text
env GROUP=QA TMPDIR=/home/crackauc/tmp /home/crackauc/.juliaup/bin/julia +1.12 --startup-file=no --project=. -e "using Pkg; Pkg.test()"

QA/alloc_tests.jl | 16/16
QA/qa.jl          | 20/20
Testing DataInterpolations tests passed
Exit status: 0
```

Formatting and spelling:

```text
/home/crackauc/.juliaup/bin/julia +1.10.12 --startup-file=no -e "using Runic; exit(Runic.main(ARGS))" -- --check --diff ext/DataInterpolationsMooncakeExt.jl test/Extensions/mooncake_tests.jl
typos ext/DataInterpolationsMooncakeExt.jl test/Extensions/mooncake_tests.jl
git diff --check
```

All exited 0 with no output.

## Not verified

No documentation build was run because this changes neither documentation nor public API.

🤖 Generated with Codex CLI (harness: Codex CLI 0.151.0; model: gpt-5.6-sol; session: local session ID 01a0598f-11b9-72d1-91d9-b2fbb186557d).

