### PR TITLE
Release DataInterpolations 10.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "10.1.0"
+version = "10.1.1"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Bumps `DataInterpolations` 10.1.0 -> 10.1.1 (patch).

Source files changed since 10.1.0:
- `src/interpolation_caches.jl`
- `src/interpolation_utils.jl`

Commits:
- docs: clarify description of Quadratic and Cubic Spline (#599)
- fix: better error for minimum number of points (#601)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
