### PR TITLE
Release DataInterpolations 10.1.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DataInterpolations"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "10.1.1"
+version = "10.1.2"
 
 [deps]
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"


### PR DESCRIPTION
Bumps `DataInterpolations` 10.1.1 -> 10.1.2 (patch).

Source files changed since 10.1.1:
- `ext/DataInterpolationsMooncakeExt.jl`
- `src/derivatives.jl`
- `src/integrals.jl`
- `src/interpolation_methods.jl`
- `src/parameter_caches.jl`

Commits:
- refactor: improve performance of LagrangeInterpolation, CubicSpline and BSplines (#602)
- fix: bound Mooncake constructor differentiation (#604)

Version bump only; no code changes in this PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code) (model: claude-opus-5[1m])

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R
