### PR TITLE
Add AirspeedVelocity benchmarking CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,29 @@
+name: Benchmark this PR
+
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ["1", "lts"]
+    env:
+      # Force consistent Julia depot path for self-hosted runners
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: ${{ matrix.version }}
+          script: "benchmark/benchmarks.jl"
+          extra-pkgs: "StableRNGs"
+          job-summary: true

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,70 @@
+using DataInterpolations, BenchmarkTools
+using StableRNGs
+
+const SUITE = BenchmarkGroup()
+const rng = StableRNG(123)
+
+# Smooth 1D data
+t = collect(range(0.0, 10.0, length = 200))
+u = sin.(t) .+ 0.5 .* cos.(3 .* t)
+t_eval = collect(range(0.05, 9.95, length = 1000))
+
+# =============================================================================
+# Construction
+# =============================================================================
+
+SUITE["construct"] = BenchmarkGroup()
+
+SUITE["construct"]["LinearInterpolation"] = @benchmarkable LinearInterpolation($u, $t)
+SUITE["construct"]["QuadraticInterpolation"] = @benchmarkable QuadraticInterpolation(
+    $u, $t
+)
+SUITE["construct"]["CubicSpline"] = @benchmarkable CubicSpline($u, $t)
+SUITE["construct"]["AkimaInterpolation"] = @benchmarkable AkimaInterpolation($u, $t)
+SUITE["construct"]["PCHIPInterpolation"] = @benchmarkable PCHIPInterpolation($u, $t)
+SUITE["construct"]["ConstantInterpolation"] = @benchmarkable ConstantInterpolation($u, $t)
+SUITE["construct"]["LagrangeInterpolation"] = @benchmarkable LagrangeInterpolation(
+    $(u[1:20]), $(t[1:20])
+)
+
+# =============================================================================
+# Evaluation
+# =============================================================================
+
+SUITE["eval"] = BenchmarkGroup()
+
+lin = LinearInterpolation(u, t)
+quad = QuadraticInterpolation(u, t)
+cubic = CubicSpline(u, t)
+akima = AkimaInterpolation(u, t)
+const_interp = ConstantInterpolation(u, t)
+
+SUITE["eval"]["linear_scalar"] = @benchmarkable $lin(5.4321)
+SUITE["eval"]["linear_vector"] = @benchmarkable $lin($t_eval)
+SUITE["eval"]["quadratic_vector"] = @benchmarkable $quad($t_eval)
+SUITE["eval"]["cubic_vector"] = @benchmarkable $cubic($t_eval)
+SUITE["eval"]["akima_vector"] = @benchmarkable $akima($t_eval)
+SUITE["eval"]["constant_vector"] = @benchmarkable $const_interp($t_eval)
+
+# =============================================================================
+# Derivatives
+# =============================================================================
+
+SUITE["derivative"] = BenchmarkGroup()
+SUITE["derivative"]["cubic"] = @benchmarkable DataInterpolations.derivative(
+    $cubic, 5.4321
+)
+SUITE["derivative"]["linear"] = @benchmarkable DataInterpolations.derivative(
+    $lin, 5.4321
+)
+
+# =============================================================================
+# Vector-valued output
+# =============================================================================
+
+SUITE["vector_valued"] = BenchmarkGroup()
+
+umat = rand(rng, 5, 200)
+lin_vv = LinearInterpolation(umat, t)
+SUITE["vector_valued"]["construct"] = @benchmarkable LinearInterpolation($umat, $t)
+SUITE["vector_valued"]["eval"] = @benchmarkable $lin_vv(5.4321)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/benchmark.yml` running AirspeedVelocity on pull requests (Julia `1` and `lts`, 30 min timeout), following the OrdinaryDiffEq.jl setup.
- Adds `benchmark/benchmarks.jl` with a small `SUITE` covering representative workloads for this package.

The suite was verified locally in a fresh environment: it loads and all benchmarks run in ~29s.

#### Test plan

- [x] `run(SUITE)` locally: all benchmarks pass (~29s)
- [x] Runic formatting clean on `benchmark/benchmarks.jl`
- [ ] \"Benchmark this PR\" workflow triggers and completes on this PR

🤖 Generated with [Devin](https://devin.ai) (harness: devin 3000.10.21, model: SWE-2 High)
Session: local transcript /home/crackauc/sandbox/tmp_20260911_112052_59120/history_6a789c0b69c64ca3.md